### PR TITLE
grpc connection management no longer yields same errors from dial

### DIFF
--- a/grpcurl.go
+++ b/grpcurl.go
@@ -854,9 +854,6 @@ func BlockingDial(ctx context.Context, address string, creds credentials.Transpo
 	// grpc.Dial doesn't provide any information on permanent connection errors (like
 	// TLS handshake failures). So in order to provide good error messages, we need a
 	// custom dialer that can provide that info. That means we manage the TLS handshake.
-	var wg sync.WaitGroup
-	wg.Add(1)
-	var once sync.Once
 	result := make(chan interface{}, 1)
 
 	writeResult := func(res interface{}) {
@@ -868,7 +865,6 @@ func BlockingDial(ctx context.Context, address string, creds credentials.Transpo
 	}
 
 	dialer := func(address string, timeout time.Duration) (net.Conn, error) {
-		once.Do(func() { wg.Done() })
 		ctx, cancel := context.WithTimeout(ctx, timeout)
 		defer cancel()
 		conn, err := (&net.Dialer{Cancel: ctx.Done()}).Dial("tcp", address)

--- a/grpcurl.go
+++ b/grpcurl.go
@@ -871,7 +871,7 @@ func BlockingDial(ctx context.Context, address string, creds credentials.Transpo
 		once.Do(func() { wg.Done() })
 		ctx, cancel := context.WithTimeout(ctx, timeout)
 		defer cancel()
-		conn, err := (&net.Dialer{}).DialContext(ctx, "tcp", address)
+		conn, err := (&net.Dialer{Cancel: ctx.Done()}).Dial("tcp", address)
 		if err != nil {
 			writeResult(err)
 			return nil, err

--- a/grpcurl.go
+++ b/grpcurl.go
@@ -15,10 +15,12 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net"
 	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/proto"
@@ -843,4 +845,76 @@ func ServerTransportCredentials(cacertFile, serverCertFile, serverKeyFile string
 	}
 
 	return credentials.NewTLS(&tlsConf), nil
+}
+
+// BlockingDial is a helper method to dial the given address, using optional TLS credentials,
+// and blocking until the returned connection is ready. If the given credentials are nil, the
+// connection will be insecure (plain-text).
+func BlockingDial(ctx context.Context, address string, creds credentials.TransportCredentials, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
+	// grpc.Dial doesn't provide any information on permanent connection errors (like
+	// TLS handshake failures). So in order to provide good error messages, we need a
+	// custom dialer that can provide that info. That means we manage the TLS handshake.
+	var wg sync.WaitGroup
+	wg.Add(1)
+	var once sync.Once
+	result := make(chan interface{}, 1)
+
+	writeResult := func(res interface{}) {
+		// non-blocking write: we only need the first result
+		select {
+		case result <- res:
+		default:
+		}
+	}
+
+	dialer := func(address string, timeout time.Duration) (net.Conn, error) {
+		once.Do(func() { wg.Done() })
+		ctx, cancel := context.WithTimeout(ctx, timeout)
+		defer cancel()
+		conn, err := (&net.Dialer{}).DialContext(ctx, "tcp", address)
+		if err != nil {
+			writeResult(err)
+			return nil, err
+		}
+		if creds != nil {
+			conn, _, err = creds.ClientHandshake(ctx, address, conn)
+			if err != nil {
+				writeResult(err)
+				return nil, err
+			}
+		}
+		return conn, nil
+	}
+
+	// Even with grpc.FailOnNonTempDialError, this call will usually timeout in
+	// the face of TLS handshake errors. So we can't rely on grpc.WithBlock() to
+	// know when we're done. So we run it in a goroutine and then use result
+	// channel to either get the channel or fail-fast.
+	go func() {
+		opts = append(opts,
+			grpc.WithBlock(),
+			grpc.FailOnNonTempDialError(true),
+			grpc.WithDialer(dialer),
+			grpc.WithInsecure(), // we are handling TLS, so tell grpc not to
+		)
+		conn, err := grpc.DialContext(ctx, address, opts...)
+		var res interface{}
+		if err != nil {
+			res = err
+		} else {
+			res = conn
+		}
+		writeResult(res)
+	}()
+
+	select {
+	case res := <-result:
+		if conn, ok := res.(*grpc.ClientConn); ok {
+			return conn, nil
+		} else {
+			return nil, res.(error)
+		}
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
 }

--- a/grpcurl.go
+++ b/grpcurl.go
@@ -685,7 +685,7 @@ func fetchAllExtensions(source DescriptorSource, ext *dynamic.ExtensionRegistry,
 		fds, err := source.AllExtensionsForType(msgTypeName)
 		for _, fd := range fds {
 			if err = ext.AddExtension(fd); err != nil {
-				return fmt.Errorf("could not register extension %d of type %s: %v", fd.GetFullyQualifiedName(), msgTypeName, err)
+				return fmt.Errorf("could not register extension %s of type %s: %v", fd.GetFullyQualifiedName(), msgTypeName, err)
 			}
 		}
 	}

--- a/grpcurl_test.go
+++ b/grpcurl_test.go
@@ -57,8 +57,10 @@ func TestMain(m *testing.M) {
 	defer svrReflect.Stop()
 
 	// And a corresponding client
-	if ccReflect, err = grpc.Dial(fmt.Sprintf("127.0.0.1:%d", portReflect),
-		grpc.WithInsecure(), grpc.WithTimeout(10*time.Second), grpc.WithBlock()); err != nil {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if ccReflect, err = grpc.DialContext(ctx, fmt.Sprintf("127.0.0.1:%d", portReflect),
+		grpc.WithInsecure(), grpc.WithBlock()); err != nil {
 		panic(err)
 	}
 	defer ccReflect.Close()
@@ -80,8 +82,10 @@ func TestMain(m *testing.M) {
 	defer svrProtoset.Stop()
 
 	// And a corresponding client
-	if ccProtoset, err = grpc.Dial(fmt.Sprintf("127.0.0.1:%d", portProtoset),
-		grpc.WithInsecure(), grpc.WithTimeout(10*time.Second), grpc.WithBlock()); err != nil {
+	ctx, cancel = context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if ccProtoset, err = grpc.DialContext(ctx, fmt.Sprintf("127.0.0.1:%d", portProtoset),
+		grpc.WithInsecure(), grpc.WithBlock()); err != nil {
 		panic(err)
 	}
 	defer ccProtoset.Close()

--- a/tls_settings_test.go
+++ b/tls_settings_test.go
@@ -126,7 +126,8 @@ func TestBrokenTLS_ClientPlainText(t *testing.T) {
 	if !strings.Contains(err.Error(), "transport is closing") &&
 		!strings.Contains(err.Error(), "connection is unavailable") &&
 		!strings.Contains(err.Error(), "use of closed network connection") &&
-		!strings.Contains(err.Error(), "all SubConns are in TransientFailure") {
+		!strings.Contains(err.Error(), "all SubConns are in TransientFailure") &&
+		!strings.Contains(err.Error(), "deadline exceeded") {
 
 		t.Fatalf("expecting transport failure, got: %v", err)
 	}


### PR DESCRIPTION
When the test was written, `grpc.Dial` returned underlying connect error on failure/timeout. Now (sadly) it only returns a context cancelled/timeout error.

Also, go "tip" version issues compile errors for format pattern mistakes and caught a problem with an error message that was using `"%d"` for a string value.

A considerable downside of this is that all connection and TLS exceptions simply get reported as timeouts 😦. I'll also be filing a bug in the GRPC project about this sudden inability to access the cause of connection errors.