### PR TITLE
make jsonpb marshaler emit defaults

### DIFF
--- a/grpcurl.go
+++ b/grpcurl.go
@@ -386,7 +386,7 @@ func invokeUnary(ctx context.Context, stub grpcdynamic.Stub, md *desc.MethodDesc
 
 	var respStr string
 	if stat.Code() == codes.OK {
-		jsm := jsonpb.Marshaler{Indent: "  "}
+		jsm := jsonpb.Marshaler{EmitDefaults: true, Indent: "  "}
 		respStr, err = jsm.MarshalToString(resp)
 		if err != nil {
 			return fmt.Errorf("failed to generate JSON form of response message: %v", err)
@@ -449,7 +449,7 @@ func invokeClientStream(ctx context.Context, stub grpcdynamic.Stub, md *desc.Met
 
 	var respStr string
 	if stat.Code() == codes.OK {
-		jsm := jsonpb.Marshaler{Indent: "  "}
+		jsm := jsonpb.Marshaler{EmitDefaults: true, Indent: "  "}
 		respStr, err = jsm.MarshalToString(resp)
 		if err != nil {
 			return fmt.Errorf("failed to generate JSON form of response message: %v", err)
@@ -502,7 +502,7 @@ func invokeServerStream(ctx context.Context, stub grpcdynamic.Stub, md *desc.Met
 			}
 			break
 		}
-		jsm := jsonpb.Marshaler{Indent: "  "}
+		jsm := jsonpb.Marshaler{EmitDefaults: true, Indent: "  "}
 		respStr, err := jsm.MarshalToString(resp)
 		if err != nil {
 			return fmt.Errorf("failed to generate JSON form of response message: %v", err)
@@ -588,7 +588,7 @@ func invokeBidi(ctx context.Context, cancel context.CancelFunc, stub grpcdynamic
 			}
 			break
 		}
-		jsm := jsonpb.Marshaler{Indent: "  "}
+		jsm := jsonpb.Marshaler{EmitDefaults: true, Indent: "  "}
 		respStr, err := jsm.MarshalToString(resp)
 		if err != nil {
 			return fmt.Errorf("failed to generate JSON form of response message: %v", err)

--- a/grpcurl.go
+++ b/grpcurl.go
@@ -263,7 +263,7 @@ type InvocationEventHandler interface {
 	// OnReceiveHeaders is called when response headers have been received.
 	OnReceiveHeaders(metadata.MD)
 	// OnReceiveResponse is called for each response message received.
-	OnReceiveResponse(json.RawMessage)
+	OnReceiveResponse(proto.Message)
 	// OnReceiveTrailers is called when response trailers and final RPC status have been received.
 	OnReceiveTrailers(*status.Status, metadata.MD)
 }
@@ -384,14 +384,8 @@ func invokeUnary(ctx context.Context, stub grpcdynamic.Stub, md *desc.MethodDesc
 
 	handler.OnReceiveHeaders(respHeaders)
 
-	var respStr string
 	if stat.Code() == codes.OK {
-		jsm := jsonpb.Marshaler{EmitDefaults: true, Indent: "  "}
-		respStr, err = jsm.MarshalToString(resp)
-		if err != nil {
-			return fmt.Errorf("failed to generate JSON form of response message: %v", err)
-		}
-		handler.OnReceiveResponse(json.RawMessage(respStr))
+		handler.OnReceiveResponse(resp)
 	}
 
 	handler.OnReceiveTrailers(stat, respTrailers)
@@ -447,14 +441,8 @@ func invokeClientStream(ctx context.Context, stub grpcdynamic.Stub, md *desc.Met
 		handler.OnReceiveHeaders(respHeaders)
 	}
 
-	var respStr string
 	if stat.Code() == codes.OK {
-		jsm := jsonpb.Marshaler{EmitDefaults: true, Indent: "  "}
-		respStr, err = jsm.MarshalToString(resp)
-		if err != nil {
-			return fmt.Errorf("failed to generate JSON form of response message: %v", err)
-		}
-		handler.OnReceiveResponse(json.RawMessage(respStr))
+		handler.OnReceiveResponse(resp)
 	}
 
 	handler.OnReceiveTrailers(stat, str.Trailer())
@@ -502,12 +490,7 @@ func invokeServerStream(ctx context.Context, stub grpcdynamic.Stub, md *desc.Met
 			}
 			break
 		}
-		jsm := jsonpb.Marshaler{EmitDefaults: true, Indent: "  "}
-		respStr, err := jsm.MarshalToString(resp)
-		if err != nil {
-			return fmt.Errorf("failed to generate JSON form of response message: %v", err)
-		}
-		handler.OnReceiveResponse(json.RawMessage(respStr))
+		handler.OnReceiveResponse(resp)
 	}
 
 	stat, ok := status.FromError(err)
@@ -588,13 +571,7 @@ func invokeBidi(ctx context.Context, cancel context.CancelFunc, stub grpcdynamic
 			}
 			break
 		}
-		jsm := jsonpb.Marshaler{EmitDefaults: true, Indent: "  "}
-		respStr, err := jsm.MarshalToString(resp)
-		if err != nil {
-			return fmt.Errorf("failed to generate JSON form of response message: %v", err)
-		}
-
-		handler.OnReceiveResponse(json.RawMessage(respStr))
+		handler.OnReceiveResponse(resp)
 	}
 
 	if se, ok := sendErr.Load().(error); ok && se != io.EOF {

--- a/grpcurl_test.go
+++ b/grpcurl_test.go
@@ -261,6 +261,20 @@ const (
     "body": "SXQncyBCdXNpbmVzcyBUaW1l"
   }
 }`
+	fullResponse1 = `{
+  "payload": {
+    "type": "COMPRESSABLE",
+    "body": "SXQncyBCdXNpbmVzcyBUaW1l"
+  },
+  "username": "",
+  "oauthScope": ""
+}`
+	response1 = `{
+  "payload": {
+    "type": "COMPRESSABLE",
+    "body": "SXQncyBCdXNpbmVzcyBUaW1l"
+  }
+}`
 	payload2 = `{
   "payload": {
     "type": "RANDOM",
@@ -292,7 +306,7 @@ func doTestUnary(t *testing.T, cc *grpc.ClientConn, source DescriptorSource) {
 	}
 
 	if h.check(t, "grpc.testing.TestService.UnaryCall", codes.OK, 1, 1) {
-		if h.respMessages[0] != payload1 {
+		if h.respMessages[0] != fullResponse1 {
 			t.Errorf("unexpected response from RPC: expecting %s; got %s", payload1, h.respMessages[0])
 		}
 	}
@@ -424,6 +438,7 @@ func TestHalfDuplexStreamReflect(t *testing.T) {
 
 func doTestHalfDuplexStream(t *testing.T, cc *grpc.ClientConn, source DescriptorSource) {
 	reqs := []string{payload1, payload2, payload3}
+	resps := []string{response1, payload2, payload3}
 
 	// Success
 	h := &handler{reqMessages: reqs}
@@ -434,8 +449,8 @@ func doTestHalfDuplexStream(t *testing.T, cc *grpc.ClientConn, source Descriptor
 
 	if h.check(t, "grpc.testing.TestService.HalfDuplexCall", codes.OK, 3, 3) {
 		for i, resp := range h.respMessages {
-			if resp != reqs[i] {
-				t.Errorf("unexpected response %d from RPC:\nexpecting %q\ngot %q", i, reqs[i], resp)
+			if resp != resps[i] {
+				t.Errorf("unexpected response %d from RPC:\nexpecting %q\ngot %q", i, resps[i], resp)
 			}
 		}
 	}


### PR DESCRIPTION
This protobuf default is really quite confusing:

Example call before:

```
$ echo '{"subjects": ["teams:admins2"], "resource": "authz:nodes:foo:run_list", "action": "nodes:read" }' | grpcurl -v -d @ localhost:9094 authz.Authorization/IsAuthorized
Resolved method descriptor:
{
  "name": "IsAuthorized",
  "inputType": ".authz.IsAuthorizedReq",
  "outputType": ".authz.IsAuthorizedResp",
  "options": {
  }
}
Request metadata to send:
(empty)
Response headers received:
content-type: application/grpc
Response contents:
{

}
```

This happened because defaults are omitted, but for a boolean response, the `false` case actually is quite interesting! 😄 

So, with this, we'd have grpcurl emit defaults, and the crucial section of the output becomes:
```
Response contents:
{
  "authorized": false
}
```

What do you think?

I could be persuaded to turn this into a flag; but that seems to require some effort to thread the config value through, so I wanted to propose the simplest thing first. 😉 

Thanks for grpcurl! It's helped our team quite a bit. 👍 