### PR TITLE
attempt to fix flaky test

### DIFF
--- a/tls_settings_test.go
+++ b/tls_settings_test.go
@@ -283,7 +283,9 @@ func TestBrokenTLS_RequireClientCertButNonePresented(t *testing.T) {
 
 func simpleTest(t *testing.T, cc *grpc.ClientConn) {
 	cl := grpc_testing.NewTestServiceClient(cc)
-	_, err := cl.UnaryCall(context.Background(), &grpc_testing.SimpleRequest{})
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	_, err := cl.UnaryCall(ctx, &grpc_testing.SimpleRequest{}, grpc.FailFast(false))
 	if err != nil {
 		t.Errorf("simple RPC failed: %v", err)
 	}
@@ -311,7 +313,7 @@ func createTestServerAndClient(serverCreds, clientCreds credentials.TransportCre
 	port := l.Addr().(*net.TCPAddr).Port
 	go svr.Serve(l)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 
 	cc, err := BlockingDial(ctx, fmt.Sprintf("127.0.0.1:%d", port), clientCreds)


### PR DESCRIPTION
The tests are usually failures to setup the connecting within 1 second. It happens much more often in Go 1.6 than others, but still happens in others (so just dropping support for 1.6, which is certainly a consideration, wouldn't truly fix the flakiness).

Sometimes the error is during the RPC call, due to transient connection issue. So turning off fail-fast should address that. Another error I've seen a couple of times is in `TestServerDoesNotSupportReflection`, due to getting an `io.EOF` error instead of the expected `ErrReflectionNotSupported`. That is a bug in grpcreflect (dependency), and it should be fixed by this patch: https://github.com/jhump/protoreflect/pull/104
