### PR TITLE
trailing message on invocation should only be printed in verbose mode

### DIFF
--- a/cmd/grpcurl/grpcurl.go
+++ b/cmd/grpcurl/grpcurl.go
@@ -386,7 +386,9 @@ func main() {
 		if h.respCount != 1 {
 			respSuffix = "s"
 		}
-		fmt.Printf("Sent %d request%s and received %d response%s\n", h.reqCount, reqSuffix, h.respCount, respSuffix)
+		if *verbose {
+			fmt.Printf("Sent %d request%s and received %d response%s\n", h.reqCount, reqSuffix, h.respCount, respSuffix)
+		}
 		if h.stat.Code() != codes.OK {
 			fmt.Fprintf(os.Stderr, "ERROR:\n  Code: %s\n  Message: %s\n", h.stat.Code().String(), h.stat.Message())
 			exit(1)


### PR DESCRIPTION
When invoking an RPC, the output to stdout is valid JSON except for the summary message that is printed. For inter-op with tools like `jq`, we can omit that message and only show it in verbose mode (which prints lots of other non-JSON stuff to stdout).

This fixes #18.