### PR TITLE
Override server name when validating TLS cert

### DIFF
--- a/cmd/grpcurl/grpcurl.go
+++ b/cmd/grpcurl/grpcurl.go
@@ -76,6 +76,7 @@ var (
 		`When describing messages, show a JSON template for the message type.`)
 	verbose = flag.Bool("v", false,
 		`Enable verbose output.`)
+	serverName = flag.String("servername", "", "Override servername when validating TLS certificate.")
 )
 
 func init() {
@@ -232,6 +233,9 @@ func main() {
 			creds, err = grpcurl.ClientTransportCredentials(*insecure, *cacert, *cert, *key)
 			if err != nil {
 				fail(err, "Failed to configure transport credentials")
+			}
+			if *serverName != "" {
+				creds.OverrideServerName(*serverName)
 			}
 		}
 		cc, err := grpcurl.BlockingDial(ctx, target, creds, opts...)


### PR DESCRIPTION
Sometimes a trusted cert's hostname cannot be identical to the DNS
label. This flag enables to override the hostname on validation, such
that one is not forced to use --insecure.