### PR TITLE
Allow passing :authority pseudo header

### DIFF
--- a/cmd/grpcurl/grpcurl.go
+++ b/cmd/grpcurl/grpcurl.go
@@ -57,7 +57,9 @@ var (
 	addlHeaders multiString
 	rpcHeaders  multiString
 	reflHeaders multiString
-	data        = flag.String("d", "",
+	authority   = flag.String("authority", "",
+		":authority pseudo header value to be passed along with underlying HTTP/2 requests. It defaults to `host [ \":\" port ]` part of the target url.")
+	data = flag.String("d", "",
 		`JSON request contents. If the value is '@' then the request contents are
     	read from stdin. For calls that accept a stream of requests, the
     	contents should include all such request messages concatenated together
@@ -255,6 +257,9 @@ func main() {
 				Time:    timeout,
 				Timeout: timeout,
 			}))
+		}
+		if *authority != "" {
+			opts = append(opts, grpc.WithAuthority(*authority))
 		}
 		var creds credentials.TransportCredentials
 		if !*plaintext {


### PR DESCRIPTION
So that you inform reverse proxy servers to use it for routing.
Tested with nginx/1.13.12, which is the latest release of nginx as of today.

Usage: `grpcurl --authority example.com localhost`

See https://github.com/grpc/grpc-go/pull/1064 for the PR to grpc-go which enabled this feature.
See https://tools.ietf.org/html/rfc7540#section-8.1.2.3 and https://tools.ietf.org/html/rfc3986#section-3.2 for what is a valid :authority header value.

Note that `grpcurl -H ':authority: example.com' localhost` doesn't work in two ways.

One is that the current implementation of grpcurl splits `:authority: example.com` to `[]string{"", "authority: example}` and considers it as a header with an empty key and a value of "authority: example.com" which isn't valid.

Another one is that `-H` passes request metadata, whereas `:authority` header must be provided at connection time.