### PR TITLE
Point to server reflection docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ In fact, the way the tool transforms JSON request data into a binary encoded pro
 is using that very same schema. So, if the server you interact with does not support
 reflection, you will need to build "protoset" files that `grpcurl` can use.
 
-[Examples for how to set up server reflection can be found here.](https://github.com/grpc/grpc/blob/master/doc/server-reflection.md#known-implementations.)
+[Examples for how to set up server reflection can be found here.](https://github.com/grpc/grpc/blob/master/doc/server-reflection.md#known-implementations)
 
 This repo also provides a library package, `github.com/fullstorydev/grpcurl`, that has
 functions for simplifying the construction of other command-line tools that dynamically

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ In fact, the way the tool transforms JSON request data into a binary encoded pro
 is using that very same schema. So, if the server you interact with does not support
 reflection, you will need to build "protoset" files that `grpcurl` can use.
 
+[Examples for how to set up server reflection can be found here.](https://github.com/grpc/grpc/blob/master/doc/server-reflection.md#known-implementations.)
+
 This repo also provides a library package, `github.com/fullstorydev/grpcurl`, that has
 functions for simplifying the construction of other command-line tools that dynamically
 invoke gRPC endpoints. This code is a great example of how to use the various packages of


### PR DESCRIPTION
Service reflection has very poor SEO and unfortunately not great discoverability. Since this package is an entry-point for service reflection, this helps make the process of finding this information easier.

Sidenote: I'm excited for the talk on grpcurl at Gophercon, and I think this will help users who investigate the package for the first time after seeing the talk. :)

Sidenote 2: I'm not absolutely sold on plopping in a huge code block right there at the top of the readme. If you prefer this in a different place, let me know,