### PR TITLE
allow period at the start of a symbol

### DIFF
--- a/cmd/grpcurl/grpcurl.go
+++ b/cmd/grpcurl/grpcurl.go
@@ -369,6 +369,10 @@ func main() {
 			symbols = svcs
 		}
 		for _, s := range symbols {
+			if s[0] == '.' {
+				s = s[1:]
+			}
+
 			dsc, err := descSource.FindSymbol(s)
 			if err != nil {
 				fail(err, "Failed to resolve symbol %q", s)


### PR DESCRIPTION
When describing a service, InputType and OutputType symbols are presented
as .Foo.Bar. However, when describing a type, .Foo.Bar is not accepted;
it must be changed to Foo.Bar. This is both confusing and breaks copy
paste ability. This commit addresses the problem by optionally allowing a
period at the beginning of a symbol.

Fixes #39.