### PR TITLE
only run extra checks for one build (Go 1.10), not all of them

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,12 @@ sudo: false
 
 matrix:
   include:
-    - go: 1.7
-    - go: 1.8
-    - go: 1.9
+    - go: "1.7"
+    - go: "1.8"
+    - go: "1.9"
+    - go: "1.10"
+      env: VET=1
     - go: tip
 
 script:
-  - make
+  - if [[ "$VET" = 1 ]]; then make; else make deps test; fi


### PR DESCRIPTION
Some of the checkers (`unused` and `staticcheck`) are no longer compatible with Go 1.8 and older. 

Also, if a standard check (`gofmt` for example) changed between Go versions, we wouldn't want a case where the build is red because the repo is correct for the latest version of the tool but marked incorrect by an older version.