### PR TITLE
improve flag doc with go 1.10+

### DIFF
--- a/cmd/grpcurl/go1_10.go
+++ b/cmd/grpcurl/go1_10.go
@@ -1,0 +1,9 @@
+// +build go1.10
+
+package main
+
+func indent() string {
+	// In Go 1.10 and up, the flag package automatically
+	// adds the right indentation.
+	return ""
+}

--- a/cmd/grpcurl/go1_9.go
+++ b/cmd/grpcurl/go1_9.go
@@ -1,0 +1,9 @@
+// +build !go1.10
+
+package main
+
+func indent() string {
+	// In Go 1.9 and older, we need to add indentation
+	// after newlines in the flag doc strings.
+	return "    \t"
+}

--- a/cmd/grpcurl/grpcurl.go
+++ b/cmd/grpcurl/grpcurl.go
@@ -529,29 +529,20 @@ Available flags:
 }
 
 func prettify(docString string) string {
-	var buf bytes.Buffer
-	first := true
-	for {
-		pos := strings.IndexByte(docString, '\n')
-		if pos < 0 {
-			pos = len(docString)
+	parts := strings.Split(docString, "\n")
+
+	// cull empty lines and also remove trailing and leading spaces
+	// from each line in the doc string
+	j := 0
+	for _, part := range parts {
+		if part == "" {
+			continue
 		}
-		line := strings.TrimSpace(docString[:pos])
-		if line != "" {
-			if first {
-				first = false
-			} else {
-				buf.WriteByte('\n')
-				buf.WriteString(indent())
-			}
-			buf.WriteString(line)
-		}
-		if pos >= len(docString) {
-			break
-		}
-		docString = docString[pos+1:]
+		parts[j] = strings.TrimSpace(part)
+		j++
 	}
-	return buf.String()
+
+	return strings.Join(parts[:j], "\n"+indent())
 }
 
 func warn(msg string, args ...interface{}) {

--- a/cmd/grpcurl/indent_test.go
+++ b/cmd/grpcurl/indent_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"bytes"
+	"flag"
+	"testing"
+)
+
+func TestFlagDocIndent(t *testing.T) {
+	// Tests the prettify() and indent() function. The indent() function
+	// differs by Go version, due to differences in "flags" package across
+	// versions. Run with multiple versions of Go to ensure that doc output
+	// is properly indented, regardless of Go version.
+
+	var fs flag.FlagSet
+	var buf bytes.Buffer
+	fs.SetOutput(&buf)
+
+	fs.String("foo", "", prettify(`
+		This is a flag doc string.
+		It has multiple lines.
+		More than two, actually.`))
+	fs.Int("bar", 100, prettify(`This is a simple flag doc string.`))
+	fs.Bool("baz", false, prettify(`
+		This is another long doc string.
+		It also has multiple lines. But not as long as the first one.`))
+
+	fs.PrintDefaults()
+
+	expected :=
+		`  -bar int
+    	This is a simple flag doc string. (default 100)
+  -baz
+    	This is another long doc string.
+    	It also has multiple lines. But not as long as the first one.
+  -foo string
+    	This is a flag doc string.
+    	It has multiple lines.
+    	More than two, actually.
+`
+
+	actual := buf.String()
+	if actual != expected {
+		t.Errorf("Flag output had wrong indentation.\nExpecting:\n%s\nGot:\n%s", expected, actual)
+	}
+}

--- a/cmd/grpcurl/unix.go
+++ b/cmd/grpcurl/unix.go
@@ -5,8 +5,8 @@ package main
 import "flag"
 
 var (
-	unix = flag.Bool("unix", false,
-		`Indicates that the server address is the path to a Unix domain socket.`)
+	unix = flag.Bool("unix", false, prettify(`
+		Indicates that the server address is the path to a Unix domain socket.`))
 )
 
 func init() {


### PR DESCRIPTION
In Go 1.10, flag doc strings get auto-indented if they consist of multiple lines. This is not the case for older versions of Go. So this change makes the `grpcurl` usage output prettier in Go 1.10 (and consistent with older versions).

It also adds a test to verify that flag usage output is right. Finally, it improves the indentation, to make the doc strings easier to read and scan with a glance.