### PR TITLE
use proto syntax for describe

### DIFF
--- a/cmd/grpcurl/formatting_test.go
+++ b/cmd/grpcurl/formatting_test.go
@@ -165,7 +165,7 @@ func TestHandler(t *testing.T) {
 
 				out := buf.String()
 				if !compare(out, expectedOutput) {
-					t.Errorf("%s: Incorrect output.", name) // Expected:\n%s\nGot:\n%s", name, expectedOutput, out)
+					t.Errorf("%s: Incorrect output. Expected:\n%s\nGot:\n%s", name, expectedOutput, out)
 				}
 			}
 		}
@@ -209,14 +209,7 @@ func makeProto() (proto.Message, error) {
 var (
 	verbosePrefix = `
 Resolved method descriptor:
-{
-  "name": "GetFiles",
-  "inputType": ".TestRequest",
-  "outputType": ".TestResponse",
-  "options": {
-    
-  }
-}
+rpc GetFiles ( .TestRequest ) returns ( .TestResponse );
 
 Request metadata to send:
 bar: 456

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/fullstorydev/grpcurl
 
 require (
 	github.com/golang/protobuf v1.1.0
-	github.com/jhump/protoreflect v1.0.0
+	github.com/jhump/protoreflect v1.1.0
 	golang.org/x/net v0.0.0-20180530234432-1e491301e022
 	google.golang.org/grpc v1.12.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/golang/protobuf v1.1.0 h1:0iH4Ffd/meGoXqF2lSAhZHt8X+cPgkfn/cb6Cce5Vpc=
 github.com/golang/protobuf v1.1.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
-github.com/jhump/protoreflect v1.0.0 h1:l94KtQ6gRI3ouKVcXNdofCQJWoHATzcI6tDizOgUaf0=
-github.com/jhump/protoreflect v1.0.0/go.mod h1:kG/zRVeS2M91gYaCvvUbPkMjjtFQS4qqjcPFzFkh2zE=
+github.com/jhump/protoreflect v1.1.0 h1:h+zsMrsiq0vIl7yWmeowmd8e8VtnWk75U04GgXA2s6Y=
+github.com/jhump/protoreflect v1.1.0/go.mod h1:kG/zRVeS2M91gYaCvvUbPkMjjtFQS4qqjcPFzFkh2zE=
 golang.org/x/net v0.0.0-20180530234432-1e491301e022 h1:MVYFTUmVD3/+ERcvRRI+P/C2+WOUimXh+Pd8LVsklZ4=
 golang.org/x/net v0.0.0-20180530234432-1e491301e022/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=


### PR DESCRIPTION
The output of using the `describe` verb was pretty gross: the JSON format of a descriptor proto. It was very verbose, yet at the same time hard to glean useful info from it.

This change makes it emit proto source instead, which is more concise but also more useful and much easier to read.

Here's an example of the difference. This is the new hotness:

```
> grpcurl -plaintext 127.0.0.1:12345 describe .Bank
Bank is a service:
service Bank {
  rpc CloseAccount ( .CloseAccountRequest ) returns ( .google.protobuf.Empty );
  rpc Deposit ( .DepositRequest ) returns ( .BalanceResponse );
  rpc GetAccounts ( .google.protobuf.Empty ) returns ( .GetAccountsResponse );
  rpc GetTransactions ( .GetTransactionsRequest ) returns ( stream .Transaction );
  rpc OpenAccount ( .OpenAccountRequest ) returns ( .Account );
  rpc Transfer ( .TransferRequest ) returns ( .TransferResponse );
  rpc Withdraw ( .WithdrawRequest ) returns ( .BalanceResponse );
}

> grpcurl -plaintext 127.0.0.1:12345 describe .Bank.OpenAccount
Bank.OpenAccount is a method:
rpc OpenAccount ( .OpenAccountRequest ) returns ( .Account );

> grpcurl -plaintext 127.0.0.1:12345 describe .OpenAccountRequest
OpenAccountRequest is a message:
message OpenAccountRequest {
  int32 initial_deposit_cents = 1;
  .Account.Type type = 2;
}

> grpcurl -plaintext 127.0.0.1:12345 describe .Account
Account is a message:
message Account {
  uint64 account_number = 1;
  .Account.Type type = 2;
  int32 balance_cents = 3;
  enum Type {
    UNKNOWN = 0;
    CHECKING = 1;
    SAVING = 2;
    MONEY_MARKET = 3;
    LINE_OF_CREDIT = 4;
    LOAN = 5;
    EQUITIES = 6;
  }
}

> grpcurl -plaintext 127.0.0.1:12345 describe .Account.Type.LOAN
Account.Type.LOAN is an enum value:
LOAN = 5;
```

And, as a reminder, here is the gross output it spits out without this change:

```
> grpcurl -plaintext 127.0.0.1:12345 describe .Bank
Bank is a service:
{
  "name": "Bank",
  "method": [
    {
      "name": "OpenAccount",
      "inputType": ".OpenAccountRequest",
      "outputType": ".Account",
      "options": {
        
      }
    },
    {
      "name": "CloseAccount",
      "inputType": ".CloseAccountRequest",
      "outputType": ".google.protobuf.Empty",
      "options": {
        
      }
    },
    {
      "name": "GetAccounts",
      "inputType": ".google.protobuf.Empty",
      "outputType": ".GetAccountsResponse",
      "options": {
        
      }
    },
    {
      "name": "GetTransactions",
      "inputType": ".GetTransactionsRequest",
      "outputType": ".Transaction",
      "options": {
        
      },
      "serverStreaming": true
    },
    {
      "name": "Deposit",
      "inputType": ".DepositRequest",
      "outputType": ".BalanceResponse",
      "options": {
        
      }
    },
    {
      "name": "Withdraw",
      "inputType": ".WithdrawRequest",
      "outputType": ".BalanceResponse",
      "options": {
        
      }
    },
    {
      "name": "Transfer",
      "inputType": ".TransferRequest",
      "outputType": ".TransferResponse",
      "options": {
        
      }
    }
  ],
  "options": {
    
  }
}

> grpcurl -plaintext 127.0.0.1:12345 describe .Bank.OpenAccount
Bank.OpenAccount is a method:
{
  "name": "OpenAccount",
  "inputType": ".OpenAccountRequest",
  "outputType": ".Account",
  "options": {
    
  }
}

> grpcurl -plaintext 127.0.0.1:12345 describe .OpenAccountRequest
OpenAccountRequest is a message:
{
  "name": "OpenAccountRequest",
  "field": [
    {
      "name": "initial_deposit_cents",
      "number": 1,
      "label": "LABEL_OPTIONAL",
      "type": "TYPE_INT32",
      "options": {
        
      },
      "jsonName": "initialDepositCents"
    },
    {
      "name": "type",
      "number": 2,
      "label": "LABEL_OPTIONAL",
      "type": "TYPE_ENUM",
      "typeName": ".Account.Type",
      "options": {
        
      },
      "jsonName": "type"
    }
  ],
  "options": {
    
  }
}

> grpcurl -plaintext 127.0.0.1:12345 describe .Account
Account is a message:
{
  "name": "Account",
  "field": [
    {
      "name": "account_number",
      "number": 1,
      "label": "LABEL_OPTIONAL",
      "type": "TYPE_UINT64",
      "options": {
        
      },
      "jsonName": "accountNumber"
    },
    {
      "name": "type",
      "number": 2,
      "label": "LABEL_OPTIONAL",
      "type": "TYPE_ENUM",
      "typeName": ".Account.Type",
      "options": {
        
      },
      "jsonName": "type"
    },
    {
      "name": "balance_cents",
      "number": 3,
      "label": "LABEL_OPTIONAL",
      "type": "TYPE_INT32",
      "options": {
        
      },
      "jsonName": "balanceCents"
    }
  ],
  "enumType": [
    {
      "name": "Type",
      "value": [
        {
          "name": "UNKNOWN",
          "number": 0,
          "options": {
            
          }
        },
        {
          "name": "CHECKING",
          "number": 1,
          "options": {
            
          }
        },
        {
          "name": "SAVING",
          "number": 2,
          "options": {
            
          }
        },
        {
          "name": "MONEY_MARKET",
          "number": 3,
          "options": {
            
          }
        },
        {
          "name": "LINE_OF_CREDIT",
          "number": 4,
          "options": {
            
          }
        },
        {
          "name": "LOAN",
          "number": 5,
          "options": {
            
          }
        },
        {
          "name": "EQUITIES",
          "number": 6,
          "options": {
            
          }
        }
      ],
      "options": {
        
      }
    }
  ],
  "options": {
    
  }
}

> grpcurl -plaintext 127.0.0.1:12345 describe .Account.Type.LOAN
Account.Type.LOAN is an enum value:
{
  "name": "LOAN",
  "number": 5,
  "options": {
    
  }
}
```