### PR TITLE
MakeTemplate should be more robust

### DIFF
--- a/cmd/grpcurl/grpcurl.go
+++ b/cmd/grpcurl/grpcurl.go
@@ -15,7 +15,6 @@ import (
 	"github.com/fullstorydev/grpcurl"
 	descpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/jhump/protoreflect/desc"
-	"github.com/jhump/protoreflect/dynamic"
 	"github.com/jhump/protoreflect/grpcreflect"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
@@ -459,7 +458,7 @@ func main() {
 			if dsc, ok := dsc.(*desc.MessageDescriptor); ok && *msgTemplate {
 				// for messages, also show a template in JSON, to make it easier to
 				// create a request to invoke an RPC
-				tmpl := grpcurl.MakeTemplate(dynamic.NewMessage(dsc))
+				tmpl := grpcurl.MakeTemplate(dsc)
 				_, formatter, err := grpcurl.RequestParserAndFormatterFor(grpcurl.Format(*format), descSource, true, false, nil)
 				if err != nil {
 					fail(err, "Failed to construct formatter for %q", *format)


### PR DESCRIPTION
We had fixed this in our internal version of the tool. Now that I've made `MakeTemplate` part of the API in the common package, it warrants receiving the same fix. Without this change, showing a template for a message that either *is* or includes `google.protobuf.Any` or `google.protobuf.Value` blows up, because the "zero value" for those types is incompatible with their canonical JSON format.

The test is also copied from our internal version of the tool.

This makes an incompatible API change to `MakeTemplate`. But since that API was *just* added to the package and has never been part of a release, I think it's okay to change it. At some point, I'll add some verbage to the README that indicates that unreleased APIs should be considered unstable until they are included in a release.