### PR TITLE
deps, including gRPC and golang.org/x/net/http2, no longer support go 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ sudo: false
 
 matrix:
   include:
-    - go: "1.7"
-    - go: "1.8"
     - go: "1.9"
     - go: "1.10"
       env: VET=1


### PR DESCRIPTION
Looks like they were waiting on App Engine to drop support for Go 1.8 and Go 1.6, which happened today. Now that this is merged, CI can't pass on older versions of Go: https://go-review.googlesource.com/c/net/+/145677/