### PR TITLE
don't use TLS 1.3, which isn't quite right yet in Go tip

### DIFF
--- a/grpcurl.go
+++ b/grpcurl.go
@@ -516,6 +516,7 @@ func ClientTransportCredentials(insecureSkipVerify bool, cacertFile, clientCertF
 // client certs. The serverCertFile and serverKeyFile must both not be blank.
 func ServerTransportCredentials(cacertFile, serverCertFile, serverKeyFile string, requireClientCerts bool) (credentials.TransportCredentials, error) {
 	var tlsConf tls.Config
+	tlsConf.MaxVersion = tls.VersionTLS12
 
 	// Load the server certificates from disk
 	certificate, err := tls.LoadX509KeyPair(serverCertFile, serverKeyFile)


### PR DESCRIPTION
Just checking to see if this code change works around the TLS-related issue that started popping up in Go tip in Travis last night.