### PR TITLE
make method invocation resilient to errors trying to load all files from server

### DIFF
--- a/format.go
+++ b/format.go
@@ -189,10 +189,14 @@ const (
 )
 
 func anyResolver(source DescriptorSource) (jsonpb.AnyResolver, error) {
-	files, err := GetAllFiles(source)
-	if err != nil {
-		return nil, err
-	}
+	// TODO: instead of pro-actively downloading file descriptors to
+	// build a dynamic resolver, it would be better if the resolver
+	// impl was lazy, and simply downloaded the descriptors as needed
+	// when asked to resolve a particular type URL
+
+	// best effort: build resolver with whatever files we can
+	// load, ignoring any errors
+	files, _ := GetAllFiles(source)
 
 	var er dynamic.ExtensionRegistry
 	for _, fd := range files {

--- a/format_test.go
+++ b/format_test.go
@@ -14,7 +14,7 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
-func TestRequestFactory(t *testing.T) {
+func TestRequestParser(t *testing.T) {
 	source, err := DescriptorSourceFromProtoSets("testing/example.protoset")
 	if err != nil {
 		t.Fatalf("failed to create descriptor source: %v", err)


### PR DESCRIPTION
Hopefully addresses #73, where an error occurs trying to resolve the `ServerReflection` service, which isn't even being used!

The code is trying to resolve that service in an attempt to enumerate *all* files that it can download from the server. This is then used to build a registry for parsing `google.protobuf.Any` messages. But this is quite heavy-handed -- not only is it overhead to try to load all files from the server, but they may never be needed if the input requests do not contain any `Any` messages.

This patch makes the loading of files for the `Any` registry best effort -- it will load what it can but basically ignore errors along the way. I've also added a TODO to make this be *not* heavy-handed: a custom `AnyResolver` could be provided that looks up descriptors lazily, as they are encountered, instead of trying to do so much work eagerly.