### PR TITLE
fix flaky test where code can be 'cancelled' unexpectedly

### DIFF
--- a/invoke.go
+++ b/invoke.go
@@ -311,6 +311,7 @@ func invokeBidi(ctx context.Context, stub grpcdynamic.Stub, md *desc.MethodDescr
 				}
 				if err != nil {
 					err = fmt.Errorf("error getting request data: %v", err)
+					cancel()
 					break
 				}
 
@@ -321,7 +322,6 @@ func invokeBidi(ctx context.Context, stub grpcdynamic.Stub, md *desc.MethodDescr
 
 			if err != nil {
 				sendErr.Store(err)
-				cancel()
 			}
 		}()
 	}


### PR DESCRIPTION
The test code was racy: if the server sent back an error code without reading any request messages, it was non-deterministic whether client would be allowed to send requests (in some case, it may not have received server's error code, and allowed the send; but it was also possible for the error to have already been received and the send would then fail).

Previously, the sending goroutine would always cancel the context, but something in gRPC is apparently looking at the context and lets the cancellation take precedence over whatever error code was actually received by the server. This means that some tests expecting to fail with a particular code (e.g. "precondition failed") could instead see a "cancelled" error code, which causes a test assertion to fail.

This fixes it: the context is only cancelled when the client really intends to cancel the RPC, which will not occur just in the course of receiving an error from the server (so the server's error code will be preserved).