### PR TITLE
use flagset

### DIFF
--- a/cmd/grpcurl/grpcurl.go
+++ b/cmd/grpcurl/grpcurl.go
@@ -88,8 +88,8 @@ var (
 		useful for preventing batch jobs that use grpcurl from hanging due to
 		slow or bad network links or due to incorrect stream method usage.`))
 	maxMsgSz = flags.Int("max-msg-sz", 0, prettify(`
-		The maximum encoded size of a message that grpcurl will accept. If not
-		specified, defaults to 4mb.`))
+		The maximum encoded size of a response message, in bytes, that grpcurl
+		will accept. If not specified, defaults to 4,194,304 (4 megabytes).`))
 	emitDefaults = flags.Bool("emit-defaults", false, prettify(`
 		Emit default values for JSON-encoded responses.`))
 	msgTemplate = flags.Bool("msg-template", false, prettify(`

--- a/cmd/grpcurl/unix.go
+++ b/cmd/grpcurl/unix.go
@@ -2,10 +2,8 @@
 
 package main
 
-import "flag"
-
 var (
-	unix = flag.Bool("unix", false, prettify(`
+	unix = flags.Bool("unix", false, prettify(`
 		Indicates that the server address is the path to a Unix domain socket.`))
 )
 


### PR DESCRIPTION
Just in case we ever link in a package that litters the default `flag.CommandLine` with its own options (which may not be appropriate to add to `grpcurl`'s CLI options), this changes it to use a custom flag set.

It also includes a revision to the flag doc for `-max-msg-sz` (to improve clarity).