### PR TITLE
latest protoreflect fixes some bugs in JSON marshaling/unmarshaling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/fullstorydev/grpcurl
 
 require (
 	github.com/golang/protobuf v1.2.0
-	github.com/jhump/protoreflect v1.1.0
+	github.com/jhump/protoreflect v1.2.0
 	golang.org/x/net v0.0.0-20180826012351-8a410e7b638d
 	google.golang.org/grpc v1.19.0
 )

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfb
 github.com/golang/protobuf v1.1.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
-github.com/jhump/protoreflect v1.1.0 h1:h+zsMrsiq0vIl7yWmeowmd8e8VtnWk75U04GgXA2s6Y=
-github.com/jhump/protoreflect v1.1.0/go.mod h1:kG/zRVeS2M91gYaCvvUbPkMjjtFQS4qqjcPFzFkh2zE=
+github.com/jhump/protoreflect v1.2.0 h1:W4HDXsqxgmE9OUmEXWaU2ZoUap/A29J5hW+zRXWbdC8=
+github.com/jhump/protoreflect v1.2.0/go.mod h1:kG/zRVeS2M91gYaCvvUbPkMjjtFQS4qqjcPFzFkh2zE=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/net v0.0.0-20180530234432-1e491301e022/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d h1:g9qWBGx4puODJTMVyoPrpoxPFgVGd+z1DZwjfRu4d0I=


### PR DESCRIPTION
A few different JSON-handling bugs will be fixed by this update:

* If a request message included a field of type `google.protobuf.Value` or `google.protobuf.ListValue` and the data that grpcurl wanted to send was a ` "null"` value or `"[]"` empty list (respectively), grpcurl would raise an error, being unable to unmarshal the request data correctly.
* If a response message included a oneof field that was set to its zero/default value, it would not be shown in the response output from grpcurl unless the `-emit-defaults` flag were used.
* If a response message included a oneof field and the `-emit-defaults` flag were used, *all* fields of the oneof would be shown, with the unset fields indicating a zero/default value.

See changes in [v1.2.0 release notes](https://github.com/jhump/protoreflect/releases/tag/v1.2.0) relating to JSON marshaling in the "github.com/jhump/protoreflect/dynamic" package.