### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/desc_source.go
+++ b/desc_source.go
@@ -109,7 +109,7 @@ func resolveFileDescriptor(unresolved map[string]*descpb.FileDescriptorProto, re
 	return result, nil
 }
 
-// DescriptorSourceFromFileDescriptorSet creates a DescriptorSource that is backed by the given
+// DescriptorSourceFromFileDescriptors creates a DescriptorSource that is backed by the given
 // file descriptors
 func DescriptorSourceFromFileDescriptors(files ...*desc.FileDescriptor) (DescriptorSource, error) {
 	fds := map[string]*desc.FileDescriptor{}


### PR DESCRIPTION
Hi, we updated an exported function comment based on best practices from [Effective Go](https://golang.org/doc/effective_go.html#commentary). It’s admittedly a relatively minor fix up. Does this help you?