### PR TITLE
staticcheck no longer runs on Go 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,16 @@ matrix:
   include:
     - go: "1.9"
     - go: "1.10"
-      env: VET=1
     - go: "1.11"
-      env: GO111MODULE=off
+      env:
+      - GO111MODULE=off
+      - VET=1
     - go: "1.11"
       env: GO111MODULE=on
     - go: "1.12"
+      env: GO111MODULE=off
+    - go: "1.12"
+      env: GO111MODULE=on
     - go: tip
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ matrix:
     - go: tip
 
 script:
-  - if [[ "$VET" = 1 ]]; then make; else make deps test; fi
+  - if [[ "$VET" = 1 ]]; then make ci; else make deps test; fi

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ dev_build_version=$(shell git describe --tags --always --dirty)
 # they are just too noisy to be a requirement for a CI -- we don't even *want*
 # to fix some of the things they consider to be violations.
 .PHONY: ci
-ci: deps checkgofmt vet staticcheck unused ineffassign predeclared test
+ci: deps checkgofmt vet staticcheck ineffassign predeclared test
 
 .PHONY: deps
 deps:
@@ -47,12 +47,7 @@ vet:
 .PHONY: staticcheck
 staticcheck:
 	@go get honnef.co/go/tools/cmd/staticcheck
-	staticcheck -ignore github.com/fullstorydev/grpcurl/tls_settings_test.go:SA1019 ./...
-
-.PHONY: unused
-unused:
-	@go get honnef.co/go/tools/cmd/unused
-	unused ./...
+	staticcheck ./...
 
 .PHONY: ineffassign
 ineffassign:

--- a/tls_settings_test.go
+++ b/tls_settings_test.go
@@ -285,7 +285,7 @@ func simpleTest(t *testing.T, cc *grpc.ClientConn) {
 	cl := grpc_testing.NewTestServiceClient(cc)
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
-	_, err := cl.UnaryCall(ctx, &grpc_testing.SimpleRequest{}, grpc.FailFast(false))
+	_, err := cl.UnaryCall(ctx, &grpc_testing.SimpleRequest{}, grpc.WaitForReady(true))
 	if err != nil {
 		t.Errorf("simple RPC failed: %v", err)
 	}


### PR DESCRIPTION
Also removes the `-ignore` arg to `staticcheck` invocation and fixes the complaint in code (now that this repo relies on new enough version of grpc-go). And removes the `unused` make target since that tool now reports itself as deprecated and superseded by `staticcheck`.