### PR TITLE
add official Dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 dist/
+VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,26 @@
 FROM golang:1.11.10-alpine as builder
 MAINTAINER FullStory Engineering
 
+# currently, a module build requires gcc (so Go tool can build
+# module-aware versions of std library; it ships only w/ the
+# non-module versions)
 RUN apk update && apk add --no-cache ca-certificates git gcc g++ libc-dev
 # create non-privileged group and user
 RUN addgroup -S grpcurl && adduser -S grpcurl -G grpcurl
 
-# build grpcurl
 WORKDIR /tmp/fullstorydev/grpcurl
 # copy just the files/sources we need to build grpcurl
 COPY VERSION *.go go.* /tmp/fullstorydev/grpcurl/
 COPY cmd /tmp/fullstorydev/grpcurl/cmd
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -o /grpcurl -ldflags "-w -extldflags \"-static\" -X \"main.version=$(cat VERSION)\"" ./cmd/grpcurl
+# and build a completely static binary (so we can use
+# scratch as basis for the final image)
+ENV CGO_ENABLED=0
+ENV GOOS=linux
+ENV GOARCH=amd64
+ENV GO111MODULE=on
+RUN go build -o /grpcurl \
+    -ldflags "-w -extldflags \"-static\" -X \"main.version=$(cat VERSION)\"" \
+    ./cmd/grpcurl
 
 # New FROM so we have a nice'n'tiny image
 FROM scratch

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM golang:1.11.10-alpine as builder
+MAINTAINER FullStory Engineering
+
+RUN apk update && apk add --no-cache ca-certificates git gcc g++ libc-dev
+# create non-privileged group and user
+RUN addgroup -S grpcurl && adduser -S grpcurl -G grpcurl
+
+# build grpcurl
+WORKDIR /tmp/fullstorydev/grpcurl
+# copy just the files/sources we need to build grpcurl
+COPY VERSION *.go go.* /tmp/fullstorydev/grpcurl/
+COPY cmd /tmp/fullstorydev/grpcurl/cmd
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -o /grpcurl -ldflags "-w -extldflags \"-static\" -X \"main.version=$(cat VERSION)\"" ./cmd/grpcurl
+
+# New FROM so we have a nice'n'tiny image
+FROM scratch
+WORKDIR /
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder /grpcurl /bin/grpcurl
+USER grpcurl
+
+ENTRYPOINT ["/bin/grpcurl"]

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,12 @@ release:
 	@GO111MODULE=off go get github.com/goreleaser/goreleaser
 	goreleaser --rm-dist
 
+.PHONY: docker
+docker:
+	@echo $(dev_build_version) > VERSION
+	docker build -t fullstorydev/grpcurl:$(dev_build_version) .
+	@rm VERSION
+
 .PHONY: checkgofmt
 checkgofmt:
 	gofmt -s -l .

--- a/cmd/grpcurl/grpcurl.go
+++ b/cmd/grpcurl/grpcurl.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -161,7 +162,7 @@ func main() {
 		os.Exit(0)
 	}
 	if *printVersion {
-		fmt.Fprintf(os.Stderr, "%s %s\n", os.Args[0], version)
+		fmt.Fprintf(os.Stderr, "%s %s\n", filepath.Base(os.Args[0]), version)
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
I tried to craft this so the resulting image is as small as possible. At the same time, trying to adhere to best practices and also make the thing as useful as possible, it does not run as a privileged user in the container and also uses the latest root certs from alpine (so that TLS connections work as long as the site's cert is a typical issuer).

I tested using these commands:
```bash
make docker
docker run fullstorydev/grpcurl:v1.3.0-1-g80b118f --help
docker run fullstorydev/grpcurl:v1.3.0-1-g80b118f api.grpc.me:443 list
```

Assuming this looks good, my plan was to use it to push a v1.3.0 image to Docker Hub and to also add a `docker push` command to the `make release` target at some point.