### PR TITLE
 Switch from native flags to posix flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,10 +127,10 @@ source or protoset files.
 grpcurl localhost:8787 list
 
 # Using compiled protoset files
-grpcurl -protoset my-protos.bin list
+grpcurl --protoset my-protos.bin list
 
 # Using proto sources
-grpcurl -import-path ../protos -proto my-stuff.proto list
+grpcurl --import-path ../protos --proto my-stuff.proto list
 ```
 
 The "list" verb also lets you see all methods in a particular service:
@@ -149,10 +149,10 @@ original source that defined the element, but it will be equivalent.
 grpcurl localhost:8787 describe my.custom.server.Service.MethodOne
 
 # Using compiled protoset files
-grpcurl -protoset my-protos.bin describe my.custom.server.Service.MethodOne
+grpcurl --protoset my-protos.bin describe my.custom.server.Service.MethodOne
 
 # Using proto sources
-grpcurl -import-path ../protos -proto my-stuff.proto describe my.custom.server.Service.MethodOne
+grpcurl --import-path ../protos --proto my-stuff.proto describe my.custom.server.Service.MethodOne
 ```
 
 ## Descriptor Sources
@@ -176,8 +176,8 @@ and ask it for its descriptors.
 To use `grpcurl` on servers that do not support reflection, you can use `.proto` source
 files.
 
-In addition to using `-proto` flags to point `grpcurl` at the relevant proto source file(s),
-you may also need to supply `-import-path` flags to tell `grpcurl` the folders from which
+In addition to using `--proto` flags to point `grpcurl` at the relevant proto source file(s),
+you may also need to supply `--import-path` flags to tell `grpcurl` the folders from which
 dependencies can be imported.
 
 Just like when compiling with `protoc`, you do *not* need to provide an import path for the

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/fullstorydev/grpcurl
 require (
 	github.com/golang/protobuf v1.3.1
 	github.com/jhump/protoreflect v1.4.4
+	github.com/spf13/pflag v1.0.3
 	golang.org/x/net v0.0.0-20190311183353-d8887717615a
 	google.golang.org/grpc v1.21.0
 )

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/jhump/protoreflect v1.4.4 h1:kySdALZUh7xRtW6UoZjjHtlR8k7rLzx5EXJFRvsO5UY=
 github.com/jhump/protoreflect v1.4.4/go.mod h1:gZ3i/BeD62fjlaIL0VW4UDMT70CTX+3m4pOnAlJ0BX8=
+github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
+github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/net v0.0.0-20180530234432-1e491301e022/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -16,6 +18,7 @@ golang.org/x/net v0.0.0-20190311183353-d8887717615a h1:oWX7TPOiFAMXLq8o0ikBYfCJV
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a h1:1BGLXjeY4akVXGgbC9HugT3Jv3hCI0z56oJR5vAMgBU=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
This is beneficial because it makes grpcurl more like curl.  Many more
flags are now common between grpcurl and curl which will help users that
are new to the tool.