### PR TITLE
it should use insecure flag instead of plaintext

### DIFF
--- a/cmd/grpcurl/grpcurl.go
+++ b/cmd/grpcurl/grpcurl.go
@@ -290,7 +290,7 @@ func main() {
 			opts = append(opts, grpc.WithAuthority(*authority))
 		}
 		var creds credentials.TransportCredentials
-		if !*plaintext {
+		if !*insecure {
 			var err error
 			creds, err = grpcurl.ClientTransportCredentials(*insecure, *cacert, *cert, *key)
 			if err != nil {


### PR DESCRIPTION
I use `-insecure` but it still give me a tls error message.

```
grpcurl -insecure localhost:8081 list
Failed to dial target host "localhost:8081": tls: first record does not look like a TLS handshake
```

After investigation, I found it seem we should use insecure flag instead of plaintext flag when we handle credentials.
After I fixed it, it works for me.

```
grpcurl -insecure localhost:8081 list
grpc.reflection.v1alpha.ServerReflection
proto.GrpcUpstreamService
```