### PR TITLE
Register gzip decoder

### DIFF
--- a/cmd/grpcurl/grpcurl.go
+++ b/cmd/grpcurl/grpcurl.go
@@ -23,6 +23,9 @@ import (
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/metadata"
 	reflectpb "google.golang.org/grpc/reflection/grpc_reflection_v1alpha"
+
+	// Register gzip compressor so compressed responses will work:
+	_ "google.golang.org/grpc/encoding/gzip"
 )
 
 var version = "dev build <no version set>"


### PR DESCRIPTION
Hello, we have a server that sends gzip compressed responses for certain RPCs. We were getting the following error:

    ERROR:
      Code: Unimplemented
      Message: grpc: Decompressor is not installed for grpc-encoding "gzip"

This PR adds the import to register the gzip compressor. Our RPCs work as expected with this included.