### PR TITLE
Activate xDS support in grpcurl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,17 @@ sudo: false
 
 matrix:
   include:
-    - go: "1.9"
-    - go: "1.10"
-    - go: "1.11"
+    - go: 1.9.x
+    - go: 1.10.x
+    - go: 1.11.x
       env:
       - GO111MODULE=off
       - VET=1
-    - go: "1.11"
+    - go: 1.11.x
       env: GO111MODULE=on
-    - go: "1.12"
+    - go: 1.12.x
       env: GO111MODULE=off
-    - go: "1.12"
+    - go: 1.12.x
       env: GO111MODULE=on
     - go: tip
 

--- a/grpcurl.go
+++ b/grpcurl.go
@@ -32,6 +32,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/metadata"
+	_ "google.golang.org/grpc/xds/experimental"
 )
 
 // ListServices uses the given descriptor source to return a sorted list of fully-qualified


### PR DESCRIPTION
Along with the version bump in https://github.com/fullstorydev/grpcurl/pull/136, this will activate xDSv2 support in [`grpcurl`](https://www.envoyproxy.io/docs/envoy/latest/api-v2/api).

@jhump Sorry for the barrage of PRs. A release with binaries would be highly appreciated after this PR.

CC @dfawley

**Edit: This change has manually been verified against an xDS server.**