### PR TITLE
cmd/grpcurl: add -allow-unknown-fields option

### DIFF
--- a/format_test.go
+++ b/format_test.go
@@ -69,7 +69,7 @@ func TestRequestParser(t *testing.T) {
 
 	for i, tc := range testCases {
 		name := fmt.Sprintf("#%d, %s, %d message(s)", i+1, tc.format, len(tc.expectedOutput))
-		rf, _, err := RequestParserAndFormatterFor(tc.format, source, false, false, strings.NewReader(tc.input))
+		rf, _, err := RequestParserAndFormatter(tc.format, source, strings.NewReader(tc.input), FormatOptions{})
 		if err != nil {
 			t.Errorf("Failed to create parser and formatter: %v", err)
 			continue
@@ -126,7 +126,7 @@ func TestHandler(t *testing.T) {
 					name += ", verbose"
 				}
 
-				_, formatter, err := RequestParserAndFormatterFor(format, source, false, !verbose, nil)
+				_, formatter, err := RequestParserAndFormatter(format, source, nil, FormatOptions{IncludeTextSeparator: !verbose})
 				if err != nil {
 					t.Errorf("Failed to create parser and formatter: %v", err)
 					continue


### PR DESCRIPTION
This PR adds a new option `-allow-unknown-fields` (its default value is `false` so the original behavior does not change) which, if present, will instruct JSON protobuf parser to ignore unknown fields present in the request.

My use case is that I have two services sharing a message. The message got extend with a new field but the services haven't been upgraded yet. The change to the message is backward compatible but I can't use `grpcurl` due to an error: `error getting request data: message type ABC has no known field named my_new_field`.