### PR TITLE
format: fix crash when emitting empty messages in text format

### DIFF
--- a/format.go
+++ b/format.go
@@ -179,7 +179,7 @@ func (tf *textFormatter) format(m proto.Message) (string, error) {
 
 	// no trailing newline needed
 	str := buf.String()
-	if str[len(str)-1] == '\n' {
+	if len(str) > 0 && str[len(str)-1] == '\n' {
 		str = str[:len(str)-1]
 	}
 


### PR DESCRIPTION
This fixes a `str[-1]` dereference if the marshaled text proto is an empty string.

There might be a better way to fix this - maybe `strings.TrimRight(str, "\n")`?