### PR TITLE
make sure we use pristine go.mod for test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,17 @@ dev_build_version=$(shell git describe --tags --always --dirty)
 # they are just too noisy to be a requirement for a CI -- we don't even *want*
 # to fix some of the things they consider to be violations.
 .PHONY: ci
-ci: deps checkgofmt vet staticcheck ineffassign predeclared test
+ci: backup_gomod deps checkgofmt vet staticcheck ineffassign predeclared restore_gomod test
+
+.PHONY: backup_gomod
+backup_gomod:
+	cp go.mod go.mod.bk
+
+.PHONY: restore_gomod
+restore_gomod:
+	if [ -f go.mod.bk ]; then \
+	    mv go.mod.bk go.mod \
+	fi
 
 .PHONY: deps
 deps:


### PR DESCRIPTION
When we vet, it looks like one of the tools is pulling in protobuf v1.4 into `go.mod`, even though the checked-in version of `go.mod` clearly specifies 1.3.5 :(

Vetting with v1.4 fails because it marks everything imported as `github.com/golang/protobuf` as deprecated (which results in a vet error), but we aren't ready to move to the new `google.golang.org/protobuf` APIs yet.

This hack is an attempt to ensure that the test step uses the pristine `go.mod` file, instead of one that may have been modified by the Go tool when running the various vet tools.