### PR TITLE
fix broken build: use a rune literal, not an int literal

### DIFF
--- a/format.go
+++ b/format.go
@@ -69,7 +69,7 @@ func (f *jsonRequestParser) NumRequests() int {
 }
 
 const (
-	textSeparatorChar = 0x1e
+	textSeparatorChar = '\x1e'
 )
 
 type textRequestParser struct {


### PR DESCRIPTION
Go tip does not like using `string(i)` where `i` is an untyped int
https://travis-ci.org/github/fullstorydev/grpcurl/jobs/686844524