### PR TITLE
unpin Go point release and alpine version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13.10-alpine3.11 as builder
+FROM golang:1.13-alpine as builder
 MAINTAINER FullStory Engineering
 
 # create non-privileged group and user


### PR DESCRIPTION
After thinking about it more, maybe repeatable Docker builds aren't as important as not having to touch the Dockerfile as often to upgrade to newer Go point releases. I personally only ever run `docker build` when doing releases and pushing the images to Docker hub. I'm not sure how many users try to build their own docker file, but presumably, if they don't want the image in Docker hub, then maybe they're not trying to reproduce the exact bits in the release anyway.