### PR TITLE
move import of xds package to cmd/grpcurl; other go.mod and Makefile tweaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ install:
 
 .PHONY: release
 release:
-	@go get github.com/goreleaser/goreleaser
+	@GO111MODULE=on go install github.com/goreleaser/goreleaser
 	goreleaser --rm-dist
 
 .PHONY: docker
@@ -46,29 +46,29 @@ vet:
 # CI is just getting latest master for dependencies like grpc.
 .PHONY: staticcheck
 staticcheck:
-	@go get honnef.co/go/tools/cmd/staticcheck
+	@GO111MODULE=on go install honnef.co/go/tools/cmd/staticcheck
 	staticcheck ./...
 
 .PHONY: ineffassign
 ineffassign:
-	@go get github.com/gordonklaus/ineffassign
+	@GO111MODULE=on go install github.com/gordonklaus/ineffassign
 	ineffassign .
 
 .PHONY: predeclared
 predeclared:
-	@go get github.com/nishanths/predeclared
+	@GO111MODULE=on go install github.com/nishanths/predeclared
 	predeclared .
 
 # Intentionally omitted from CI, but target here for ad-hoc reports.
 .PHONY: golint
 golint:
-	@go get golang.org/x/lint/golint
+	@GO111MODULE=on go install golang.org/x/lint/golint
 	golint -min_confidence 0.9 -set_exit_status ./...
 
 # Intentionally omitted from CI, but target here for ad-hoc reports.
 .PHONY: errcheck
 errcheck:
-	@go get github.com/kisielk/errcheck
+	@GO111MODULE=on go install github.com/kisielk/errcheck
 	errcheck ./...
 
 .PHONY: test

--- a/cmd/grpcurl/grpcurl.go
+++ b/cmd/grpcurl/grpcurl.go
@@ -26,8 +26,10 @@ import (
 	reflectpb "google.golang.org/grpc/reflection/grpc_reflection_v1alpha"
 	"google.golang.org/grpc/status"
 
-	// Register gzip compressor so compressed responses will work:
+	// Register gzip compressor so compressed responses will work
 	_ "google.golang.org/grpc/encoding/gzip"
+	// Register xds so xds and xds-experimental resolver schemes work
+	_ "google.golang.org/grpc/xds"
 )
 
 // To avoid confusion between program error codes and the gRPC resonse

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,14 @@
 module github.com/fullstorydev/grpcurl
 
+go 1.13
+
 require (
 	github.com/golang/protobuf v1.3.5
 	github.com/gordonklaus/ineffassign v0.0.0-20200309095847-7953dde2c7bf // indirect
 	github.com/goreleaser/goreleaser v0.134.0 // indirect
 	github.com/jhump/protoreflect v1.6.1
-	github.com/nishanths/predeclared v0.0.0-20190419143655-18a43bb90ffc // indirect
+	github.com/nishanths/predeclared v0.0.0-20200524104333-86fad755b4d3 // indirect
 	golang.org/x/net v0.0.0-20200226121028-0de0cce0169b
 	google.golang.org/grpc v1.30.0
-	honnef.co/go/tools v0.0.1-2020.1.3 // indirect
+	honnef.co/go/tools v0.0.1-2020.1.4 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -220,6 +220,8 @@ github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nishanths/predeclared v0.0.0-20190419143655-18a43bb90ffc h1:0NtlnvxTh8fQsQm55+bkvrqgn0zcv+M4TF8otNCuYl4=
 github.com/nishanths/predeclared v0.0.0-20190419143655-18a43bb90ffc/go.mod h1:62PewwiQTlm/7Rj+cxVYqZvDIUc+JjZq6GHAC1fsObQ=
+github.com/nishanths/predeclared v0.0.0-20200524104333-86fad755b4d3 h1:3f0nxAmdj/VoCGN/ijdMy7bj6SBagaqYg1B0hu8clMA=
+github.com/nishanths/predeclared v0.0.0-20200524104333-86fad755b4d3/go.mod h1:nt3d53pc1VYcphSCIaYAJtnPYnr3Zyn8fMq2wvPGPso=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
@@ -391,6 +393,8 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191130070609-6e064ea0cf2d/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200426102838-f3a5411a4c3b h1:zSzQJAznWxAh9fZxiPy2FZo+ZZEYoYFYYDYdOrU7AaM=
 golang.org/x/tools v0.0.0-20200426102838-f3a5411a4c3b/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
+golang.org/x/tools v0.0.0-20200522201501-cb1345f3a375 h1:SjQ2+AKWgZLc1xej6WSzL+Dfs5Uyd5xcZH1mGC411IA=
+golang.org/x/tools v0.0.0-20200522201501-cb1345f3a375/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
@@ -452,5 +456,7 @@ honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.1-2020.1.3 h1:sXmLre5bzIR6ypkjXCDI3jHPssRhc8KD/Ome589sc3U=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
+honnef.co/go/tools v0.0.1-2020.1.4 h1:UoveltGrhghAA7ePc+e+QYDHXrBps2PqFZiHkGR/xK8=
+honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 pack.ag/amqp v0.11.2/go.mod h1:4/cbmt4EJXSKlG6LCfWHoqmN0uFdy5i/+YFz+fTfhV4=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=

--- a/grpcurl.go
+++ b/grpcurl.go
@@ -32,7 +32,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/metadata"
-	_ "google.golang.org/grpc/xds"
 )
 
 // ListServices uses the given descriptor source to return a sorted list of fully-qualified


### PR DESCRIPTION
My main intent was to move the import of "google.golang.org/grpc/xds" out of the main API package and into the main command package (since it's the command that needs its `init` functions to have run, not the API).

But I ran into an issue testing: some deps kept auto-upgrading when running `make ci`. I realized it was because the make targets were relying on a pre-modules formulation -- using `go get`. But this causes the Go tool to retrieve the latest version, which would then change the version pinned in `go.mod`. So I changed all of these to `GO111MODULE=on go install`, so they just use the version already pinned.

I went ahead and left the deps upgraded though (for `staticcheck` and `predeclared` CI checkers).