### PR TITLE
no more support for go 1.11 without modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ sudo: false
 matrix:
   include:
     - go: 1.11.x
-      env: GO111MODULE=off
-    - go: 1.11.x
       env: GO111MODULE=on
     - go: 1.12.x
       env: GO111MODULE=off


### PR DESCRIPTION
When not running in modules mode, CI `go get`s the latest version of all dependencies. But the [latest grpc module](https://github.com/grpc/grpc-go/pull/3767) (as of like 4 hours ago) no longer supports Go 1.11.

So we can't run CI for Go 1.11 in non-module mode.