### PR TITLE
format gRPC status errors when using reflection

### DIFF
--- a/cmd/grpcurl/grpcurl.go
+++ b/cmd/grpcurl/grpcurl.go
@@ -695,7 +695,11 @@ func main() {
 
 		err = grpcurl.InvokeRPC(ctx, descSource, cc, symbol, append(addlHeaders, rpcHeaders...), h, rf.Next)
 		if err != nil {
-			fail(err, "Error invoking method %q", symbol)
+			if errStatus, ok := status.FromError(err); ok {
+				h.Status = errStatus
+			} else {
+				fail(err, "Error invoking method %q", symbol)
+			}
 		}
 		reqSuffix := ""
 		respSuffix := ""

--- a/cmd/grpcurl/grpcurl.go
+++ b/cmd/grpcurl/grpcurl.go
@@ -695,7 +695,7 @@ func main() {
 
 		err = grpcurl.InvokeRPC(ctx, descSource, cc, symbol, append(addlHeaders, rpcHeaders...), h, rf.Next)
 		if err != nil {
-			if errStatus, ok := status.FromError(err); ok {
+			if errStatus, ok := status.FromError(err); ok && *formatError {
 				h.Status = errStatus
 			} else {
 				fail(err, "Error invoking method %q", symbol)

--- a/invoke.go
+++ b/invoke.go
@@ -93,10 +93,15 @@ func InvokeRPC(ctx context.Context, source DescriptorSource, ch grpcdynamic.Chan
 	if svc == "" || mth == "" {
 		return fmt.Errorf("given method name %q is not in expected format: 'service/method' or 'service.method'", methodName)
 	}
+
 	dsc, err := source.FindSymbol(svc)
 	if err != nil {
 		if isNotFoundError(err) {
 			return fmt.Errorf("target server does not expose service %q", svc)
+		}
+		// return the error unstringified if it is a gRPC status.Status error
+		if _, ok := status.FromError(err); ok {
+			return err
 		}
 		return fmt.Errorf("failed to query for service descriptor %q: %v", svc, err)
 	}

--- a/invoke.go
+++ b/invoke.go
@@ -101,7 +101,7 @@ func InvokeRPC(ctx context.Context, source DescriptorSource, ch grpcdynamic.Chan
 		}
 		// return the error unstringified if it is a gRPC status error
 		if statusErr, ok := status.FromError(err); ok {
-			return status.Errorf(statusErr.Code(), "failed to query for service descriptor %q: %v", svc, err)
+			return status.Errorf(statusErr.Code(), "failed to query for service descriptor %q: %s", svc, statusErr.Message())
 		}
 		return fmt.Errorf("failed to query for service descriptor %q: %v", svc, err)
 	}

--- a/invoke.go
+++ b/invoke.go
@@ -100,8 +100,8 @@ func InvokeRPC(ctx context.Context, source DescriptorSource, ch grpcdynamic.Chan
 			return fmt.Errorf("target server does not expose service %q", svc)
 		}
 		// return the error unstringified if it is a gRPC status error
-		if statusErr, ok := status.FromError(err); ok {
-			return status.Errorf(statusErr.Code(), "failed to query for service descriptor %q: %s", svc, statusErr.Message())
+		if errStatus, ok := status.FromError(err); ok {
+			return status.Errorf(errStatus.Code(), "failed to query for service descriptor %q: %s", svc, errStatus.Message())
 		}
 		return fmt.Errorf("failed to query for service descriptor %q: %v", svc, err)
 	}

--- a/invoke.go
+++ b/invoke.go
@@ -99,9 +99,9 @@ func InvokeRPC(ctx context.Context, source DescriptorSource, ch grpcdynamic.Chan
 		if isNotFoundError(err) {
 			return fmt.Errorf("target server does not expose service %q", svc)
 		}
-		// return the error unstringified if it is a gRPC status.Status error
-		if _, ok := status.FromError(err); ok {
-			return err
+		// return the error unstringified if it is a gRPC status error
+		if statusErr, ok := status.FromError(err); ok {
+			return status.Errorf(statusErr.Code(), "failed to query for service descriptor %q: %v", svc, err)
 		}
 		return fmt.Errorf("failed to query for service descriptor %q: %v", svc, err)
 	}


### PR DESCRIPTION
Current grpc `status.Status` errors propagated from relection do not respect the `-format-error` flag:

```
$ grpcurl -format-error -H "$EXPIRED_TOKEN" -d '{}' grpc.example.com:8000 method.to.Reflect.Here

Error invoking method "method.to.Reflect.Here": failed to query for service descriptor "method.to.Reflect": rpc error: code = Unauthenticated desc = rpc error: code = Unauthenticated desc = invalid auth token: Token is expired

```

This is due to the error being stringified irrespective of any flags:

https://github.com/fullstorydev/grpcurl/blob/9846afccbc2f34255dfb459dc6f0196a2b6dbe05/invoke.go#L101

---

Propagating the preserved gRPC status error in `gprcurl.InvokeRPC` if `status.FromErrror` is ok correctly produces the expected behaviour when `formatError` is set to true:
```
$ grpcurl -format-error -H "$EXPIRED_TOKEN" -d '{}' grpc.example.com:8000 method.to.Reflect.Here

{
  "code": 16,
  "message": "rpc error: code = Unauthenticated desc = invalid auth token: Token is expired"
}
```
