### PR TITLE
Add option to disable CloseSend()

### DIFF
--- a/cmd/grpcurl/grpcurl.go
+++ b/cmd/grpcurl/grpcurl.go
@@ -122,6 +122,9 @@ var (
 		probe is sent. If the connection remains idle and no keepalive response
 		is received for this same period then the connection is closed and the
 		operation fails.`))
+	disableHalfClose = flags.Bool("disable-half-close", false, prettify(`
+		If true, the client will not call CloseSend() on the stream after all
+		request messages have been sent.`))
 	maxTime = flags.Float64("max-time", 0, prettify(`
 		The maximum total time the operation can take, in seconds. This is
 		useful for preventing batch jobs that use grpcurl from hanging due to
@@ -696,7 +699,7 @@ func main() {
 			VerbosityLevel: verbosityLevel,
 		}
 
-		err = grpcurl.InvokeRPC(ctx, descSource, cc, symbol, append(addlHeaders, rpcHeaders...), h, rf.Next)
+		err = grpcurl.InvokeRPC(ctx, descSource, cc, symbol, append(addlHeaders, rpcHeaders...), h, rf.Next, !(*disableHalfClose))
 		if err != nil {
 			if errStatus, ok := status.FromError(err); ok && *formatError {
 				h.Status = errStatus


### PR DESCRIPTION
The current implementation calls `CloseSend` on bidirectional stream once full request has been read. With `grpc-go`, this results in an `io.EOF` on the server side when server calls `Recv()`. According to http2/grpc semantic, this should result in the stream to be put into half-closed state, where server should no longer try to receive messages from client, but may still choose to keep the stream open. The specific behavior of the server can differ depending on user implementation, so I would like to control whether grpcurl uses `CloseSend()`, depending what server I'm interacting with.

This is not a fully flushed out PR (tests, style, comments etc), but the behavior does match what I want. I'm interested in some early feedback if this is something maintainers would be open to consider.