### PR TITLE
added condition on logging of JSON Response

### DIFF
--- a/format.go
+++ b/format.go
@@ -478,7 +478,9 @@ func (h *DefaultEventHandler) OnReceiveResponse(resp proto.Message) {
 	if respStr, err := h.Formatter(resp); err != nil {
 		fmt.Fprintf(h.Out, "Failed to format response message %d: %v\n", h.NumResponses, err)
 	} else {
-		fmt.Fprintln(h.Out, respStr)
+		if h.VerbosityLevel > 0 {
+			fmt.Fprintln(h.Out, respStr)
+		}
 	}
 }
 


### PR DESCRIPTION
**Rationale:**
In the case of large JSON responses, this will protect us from excessive logging.

More details on : https://github.com/ExpediaGroup/mittens/pull/160