### PR TITLE
Support SSLKEYLOGFILE environment variable for secrets logging

### DIFF
--- a/cmd/grpcurl/grpcurl.go
+++ b/cmd/grpcurl/grpcurl.go
@@ -410,13 +410,14 @@ func main() {
 		if !*plaintext {
 			tlsConf, err := grpcurl.ClientTLSConfig(*insecure, *cacert, *cert, *key)
 			if err != nil {
-				fail(err, "Failed to configure TLS config")
+				fail(err, "Failed to create TLS config")
 			}
 
-			if os.Getenv("SSLKEYLOGFILE") != "" {
-				w, err := os.OpenFile(os.Getenv("SSLKEYLOGFILE"), os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0600)
+			sslKeylogFile := os.Getenv("SSLKEYLOGFILE")
+			if sslKeylogFile != "" {
+				w, err := os.OpenFile(sslKeylogFile, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0600)
 				if err != nil {
-					fail(err, "Could not open SSLKEYLOGFILE: %v")
+					fail(err, "Could not open SSLKEYLOGFILE %s", sslKeylogFile)
 				}
 				tlsConf.KeyLogWriter = w
 			}

--- a/grpcurl.go
+++ b/grpcurl.go
@@ -508,9 +508,11 @@ func makeTemplate(md *desc.MessageDescriptor, path []*desc.MessageDescriptor) pr
 	return dm
 }
 
-// ClientTransportCredentials is a thin wrapper around ClientTLSConfig, kept for BC.
-// ClientTLSConfig offers more flexibility, as the caller can customize the tls.Config
-// struct.
+// ClientTransportCredentials is a helper function that constructs a TLS config with
+// the given properties (see ClientTLSConfig) and then constructs and returns gRPC
+// transport credentials using that config.
+//
+// Deprecated: Use grpcurl.ClientTLSConfig and credentials.NewTLS instead.
 func ClientTransportCredentials(insecureSkipVerify bool, cacertFile, clientCertFile, clientKeyFile string) (credentials.TransportCredentials, error) {
 	tlsConf, err := ClientTLSConfig(insecureSkipVerify, cacertFile, clientCertFile, clientKeyFile)
 	if err != nil {
@@ -520,7 +522,7 @@ func ClientTransportCredentials(insecureSkipVerify bool, cacertFile, clientCertF
 	return credentials.NewTLS(tlsConf), nil
 }
 
-// ClientTLSConfig builds transport credentials for a gRPC client using the
+// ClientTLSConfig builds transport-layer config for a gRPC client using the
 // given properties. If cacertFile is blank, only standard trusted certs are used to
 // verify the server certs. If clientCertFile is blank, the client will not use a client
 // certificate. If clientCertFile is not blank then clientKeyFile must not be blank.

--- a/grpcurl.go
+++ b/grpcurl.go
@@ -542,6 +542,14 @@ func ClientTransportCredentials(insecureSkipVerify bool, cacertFile, clientCertF
 		tlsConf.RootCAs = certPool
 	}
 
+	if os.Getenv("SSLKEYLOGFILE") != "" {
+		w, err := os.OpenFile(os.Getenv("SSLKEYLOGFILE"), os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0600)
+		if err != nil {
+			return nil, fmt.Errorf("could not open SSLKEYLOGFILE: %v", err)
+		}
+		tlsConf.KeyLogWriter = w
+	}
+
 	return credentials.NewTLS(&tlsConf), nil
 }
 

--- a/grpcurl.go
+++ b/grpcurl.go
@@ -554,14 +554,6 @@ func ClientTLSConfig(insecureSkipVerify bool, cacertFile, clientCertFile, client
 		tlsConf.RootCAs = certPool
 	}
 
-	if os.Getenv("SSLKEYLOGFILE") != "" {
-		w, err := os.OpenFile(os.Getenv("SSLKEYLOGFILE"), os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0600)
-		if err != nil {
-			return nil, fmt.Errorf("could not open SSLKEYLOGFILE: %v", err)
-		}
-		tlsConf.KeyLogWriter = w
-	}
-
 	return &tlsConf, nil
 }
 


### PR DESCRIPTION
I was trying to debug an issue with wireshark via:

```
$ grpcurl -vv -cacert gdk/localhost.crt localhost:1337 list
Failed to list services: rpc error: code = Unavailable desc = Service Unavailable: HTTP status code 503; transport: received the unexpected content-type "text/html"
```

Wireshark supports [consuming a key log file](https://wiki.wireshark.org/TLS#Using_the_.28Pre.29-Master-Secret), which is supported by several clients using `SSLKEYLOGFILE`, including:

* [Firefox](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/Key_Log_Format)
* Chrome
* [Curl](https://everything.curl.dev/usingcurl/tls/sslkeylogfile)

This patch adds the same capability to grpcurl.

I tested with wireshark and am able to peek inside the TLS packets.