### PR TITLE
invoking client-streaming RPC can panic

### DIFF
--- a/invoke.go
+++ b/invoke.go
@@ -227,15 +227,19 @@ func invokeClientStream(ctx context.Context, stub grpcdynamic.Stub, md *desc.Met
 		return fmt.Errorf("grpc call for %q failed: %v", md.GetFullyQualifiedName(), err)
 	}
 
-	if respHeaders, err := str.Header(); err == nil {
-		handler.OnReceiveHeaders(respHeaders)
+	if str != nil {
+		if respHeaders, err := str.Header(); err == nil {
+			handler.OnReceiveHeaders(respHeaders)
+		}
 	}
 
 	if stat.Code() == codes.OK {
 		handler.OnReceiveResponse(resp)
 	}
 
-	handler.OnReceiveTrailers(stat, str.Trailer())
+	if str != nil {
+		handler.OnReceiveTrailers(stat, str.Trailer())
+	}
 
 	return nil
 }
@@ -334,8 +338,10 @@ func invokeBidi(ctx context.Context, stub grpcdynamic.Stub, md *desc.MethodDescr
 		}()
 	}
 
-	if respHeaders, err := str.Header(); err == nil {
-		handler.OnReceiveHeaders(respHeaders)
+	if str != nil {
+		if respHeaders, err := str.Header(); err == nil {
+			handler.OnReceiveHeaders(respHeaders)
+		}
 	}
 
 	// Download each response message
@@ -362,7 +368,9 @@ func invokeBidi(ctx context.Context, stub grpcdynamic.Stub, md *desc.MethodDescr
 		return fmt.Errorf("grpc call for %q failed: %v", md.GetFullyQualifiedName(), err)
 	}
 
-	handler.OnReceiveTrailers(stat, str.Trailer())
+	if str != nil {
+		handler.OnReceiveTrailers(stat, str.Trailer())
+	}
 
 	return nil
 }


### PR DESCRIPTION
This is a possible panic in the function in grpcurl that handles dynamic invocation of an RPC.

I actually encountered this panic when using grpcui and testing a client stream RPC -- I had stopped the RPC server and then clicked "invoke" in the web UI. So creation of the client stream failed.

This bug exists only for RPCs with client streams -- which means client-streaming RPCs and bidi-stream RPCs.