### PR TITLE
Set value of creds instead of creating new variable

### DIFF
--- a/cmd/grpcurl/grpcurl.go
+++ b/cmd/grpcurl/grpcurl.go
@@ -422,7 +422,7 @@ func main() {
 				tlsConf.KeyLogWriter = w
 			}
 
-			creds := credentials.NewTLS(tlsConf)
+			creds = credentials.NewTLS(tlsConf)
 
 			// can use either -servername or -authority; but not both
 			if *serverName != "" && *authority != "" {


### PR DESCRIPTION
The `creds` variable was being redeclared instead of having the existing variable's value set.