### PR TITLE
fix release script

### DIFF
--- a/releasing/do-release.sh
+++ b/releasing/do-release.sh
@@ -47,7 +47,7 @@ echo "$VERSION" > VERSION
 $PREFIX docker run --privileged --rm tonistiigi/binfmt:qemu-v6.1.0 --install all
 # Create a new builder instance
 export DOCKER_CLI_EXPERIMENTAL=enabled
-$PREFIX docker buildx create --use --name multiarch-builder
+$PREFIX docker buildx create --use --name multiarch-builder --node multiarch-builder0
 # push to docker hub, both the given version as a tag and for "latest" tag
 $PREFIX docker buildx build --platform linux/amd64,linux/s390x,linux/arm64 --tag fullstorydev/grpcurl:${VERSION} --tag fullstorydev/grpcurl:latest --push --progress plain --no-cache .
 rm VERSION


### PR DESCRIPTION
The step that creates a docker build context is not idempotent: if you re-run the release script, you get an error:

```
existing instance for multiarch-builder but no append mode, specify --node to make changes for existing instances
```

This fixes that step.