### PR TITLE
no longer supporting go 1.14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,12 +10,6 @@ shared_configs:
 # Use the latest 2.1 version of CircleCI pipeline process engine. See: https://circleci.com/docs/2.0/configuration-reference
 version: 2.1
 jobs:
-  build-1-14:
-    working_directory: ~/repo
-    docker:
-      - image: circleci/golang:1.14
-    steps: *simple_job_steps
-
   build-1-15:
     working_directory: ~/repo
     docker:
@@ -56,7 +50,6 @@ jobs:
 workflows:
   pr-build-test:
     jobs:
-      - build-1-14
       - build-1-15
       - build-1-16
       - build-1-17


### PR DESCRIPTION
Since #240, `go.mod` already states that 1.15 is needed to build this repo.

Recent changes to update deps now _require_ 1.15 in order to build and run tests. So this officially removes 1.14 support.