### PR TITLE
Restore support for linux/s390x for the next release.

### DIFF
--- a/releasing/do-release.sh
+++ b/releasing/do-release.sh
@@ -49,7 +49,7 @@ $PREFIX docker run --privileged --rm tonistiigi/binfmt:qemu-v6.1.0 --install all
 export DOCKER_CLI_EXPERIMENTAL=enabled
 $PREFIX docker buildx create --use --name multiarch-builder --node multiarch-builder0
 # push to docker hub, both the given version as a tag and for "latest" tag
-$PREFIX docker buildx build --platform linux/amd64,linux/arm64 --tag fullstorydev/grpcurl:${VERSION} --tag fullstorydev/grpcurl:latest --push --progress plain --no-cache .
+$PREFIX docker buildx build --platform linux/amd64,linux/s390x,linux/arm64 --tag fullstorydev/grpcurl:${VERSION} --tag fullstorydev/grpcurl:latest --push --progress plain --no-cache .
 rm VERSION
 
 # Homebrew release


### PR DESCRIPTION
This reverts commit 8ee6c9423b655f2272fb1860040e73b0d198656a.

For the most recent release (v1.8.6), the docker images were built from a Linux VM (instead of from a Macbook Pro, like some earlier releases). Linux ostensibly does not have the same issue with qemu emulating s390x architecture that x86 OS X does, so we can add this back.