### PR TITLE
Adding power(ppc64le) arch support

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,6 +10,7 @@ builds:
       - 386
       - arm64
       - s390x
+      - ppc64le
     ignore:
       - goos: darwin
         goarch: 386
@@ -19,6 +20,10 @@ builds:
         goarch: s390x
       - goos: windows
         goarch: s390x
+      - goos: darwin
+        goarch: ppc64le
+      - goos: windows
+        goarch: ppc64le
     ldflags:
       - -s -w -X main.version=v{{.Version}}
 

--- a/releasing/do-release.sh
+++ b/releasing/do-release.sh
@@ -49,7 +49,7 @@ $PREFIX docker run --privileged --rm tonistiigi/binfmt:qemu-v6.1.0 --install all
 export DOCKER_CLI_EXPERIMENTAL=enabled
 $PREFIX docker buildx create --use --name multiarch-builder --node multiarch-builder0
 # push to docker hub, both the given version as a tag and for "latest" tag
-$PREFIX docker buildx build --platform linux/amd64,linux/s390x,linux/arm64 --tag fullstorydev/grpcurl:${VERSION} --tag fullstorydev/grpcurl:latest --push --progress plain --no-cache .
+$PREFIX docker buildx build --platform linux/amd64,linux/s390x,linux/arm64,linux/ppc64le --tag fullstorydev/grpcurl:${VERSION} --tag fullstorydev/grpcurl:latest --push --progress plain --no-cache .
 rm VERSION
 
 # Homebrew release


### PR DESCRIPTION
Needing power(ppc64le) arch based "grpcurl" binaries here https://docs.openshift.com/container-platform/4.9/operators/admin/olm-restricted-networks.html
1. Adding power support for releases and docker images(multi-arch).

signed-off-by : Amit Ghatwal <ghatwala@us.ibm.com>