### PR TITLE
build alpine base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,15 @@ RUN go build -o /grpcurl \
     -ldflags "-w -extldflags \"-static\" -X \"main.version=$(cat VERSION)\"" \
     ./cmd/grpcurl
 
+FROM alpine:3 as alpine
+WORKDIR /
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder /grpcurl /bin/grpcurl
+USER grpcurl
+
+ENTRYPOINT ["/bin/grpcurl"]
+
 # New FROM so we have a nice'n'tiny image
 FROM scratch
 WORKDIR /

--- a/releasing/README.md
+++ b/releasing/README.md
@@ -59,11 +59,15 @@ To re-run only the Docker Hub release steps, we need to build an image with the 
 # from the root of the repo
 echo v2.3.4 > VERSION
 docker build -t fullstorydev/grpcurl:v2.3.4 .
+docker build -t fullstorydev/grpcurl:v2.3.4-alpine --target alpine .
 # now that we have it built, push to Docker Hub
 docker push fullstorydev/grpcurl:v2.3.4
+docker push fullstorydev/grpcurl:v2.3.4-alpine
 # push "latest" tag, too
 docker tag fullstorydev/grpcurl:v2.3.4 fullstorydev/grpcurl:latest
+docker tag fullstorydev/grpcurl:v2.3.4-alpine fullstorydev/grpcurl:latest-alpine
 docker push fullstorydev/grpcurl:latest
+docker push fullstorydev/grpcurl:latest-alpine
 ```
 
 If the `docker push ...` steps fail, you may need to run `docker login`, enter your Docker Hub login credentials, and then try to push again.

--- a/releasing/do-release.sh
+++ b/releasing/do-release.sh
@@ -51,6 +51,8 @@ $PREFIX docker buildx create --use --name multiarch-builder --node multiarch-bui
 # push to docker hub, both the given version as a tag and for "latest" tag
 $PREFIX docker buildx build --platform linux/amd64,linux/s390x,linux/arm64 --tag fullstorydev/grpcurl:${VERSION} --tag fullstorydev/grpcurl:latest --push --progress plain --no-cache .
 rm VERSION
+$PREFIX docker buildx build --platform linux/amd64,linux/s390x,linux/arm64 --tag fullstorydev/grpcurl:${VERSION}-alpine --tag fullstorydev/grpcurl:latest-alpine --push --progress plain --no-cache --target alpine .
+rm VERSION
 
 # Homebrew release
 


### PR DESCRIPTION
Could you push an alpine base image version?

Then you could support more complex commands like this:

```
grpcurl -plaintext \
             -H "Authorization: Bearer $$(cat /var/run/secrets/tokens/vault-token)" \
             localhost:80 \
             example.v1.Service/Func
```

This works with a common auth pattern on kubernetes where auth tokens are mounted into a volume on a pod.

```
apiVersion: v1
kind: Pod
metadata:
  name: nginx
spec:
  containers:
  - image: nginx
    name: nginx
    volumeMounts:
    - mountPath: /var/run/secrets/tokens
      name: vault-token
  serviceAccountName: build-robot
  volumes:
  - name: vault-token
    projected:
      sources:
      - serviceAccountToken:
          path: vault-token
          expirationSeconds: 7200
          audience: vault
```
