### PR TITLE
feat: add -keep-proto-names flag

### DIFF
--- a/cmd/grpcurl/grpcurl.go
+++ b/cmd/grpcurl/grpcurl.go
@@ -131,6 +131,8 @@ var (
 		will accept. If not specified, defaults to 4,194,304 (4 megabytes).`))
 	emitDefaults = flags.Bool("emit-defaults", false, prettify(`
 		Emit default values for JSON-encoded responses.`))
+	keepProtoNames = flags.Bool("keep-proto-names", false, prettify(`
+		Use the original protobuf name for fields instead of lowerCamelCase, for JSON-encoded responses.`))
 	protosetOut = flags.String("protoset-out", "", prettify(`
 		The name of a file to be written that will contain a FileDescriptorSet
 		proto. With the list and describe verbs, the listed or described
@@ -298,6 +300,9 @@ func main() {
 	}
 	if *emitDefaults && *format != "json" {
 		warn("The -emit-defaults is only used when using json format.")
+	}
+	if *keepProtoNames && *format != "json" {
+		warn("The -keep-proto-names is only used when using json format.")
 	}
 
 	args := flags.Args()
@@ -691,6 +696,7 @@ func main() {
 		includeSeparators := verbosityLevel == 0
 		options := grpcurl.FormatOptions{
 			EmitJSONDefaultFields: *emitDefaults,
+			OrigName:              *keepProtoNames,
 			IncludeTextSeparator:  includeSeparators,
 			AllowUnknownFields:    *allowUnknownFields,
 		}

--- a/format.go
+++ b/format.go
@@ -133,11 +133,12 @@ type Formatter func(proto.Message) (string, error)
 // include empty/default values (instead of just omitted them) if emitDefaults
 // is true. The given resolver is used to assist with encoding of
 // google.protobuf.Any messages.
-func NewJSONFormatter(emitDefaults bool, resolver jsonpb.AnyResolver) Formatter {
+func NewJSONFormatter(emitDefaults, origName bool, resolver jsonpb.AnyResolver) Formatter {
 	marshaler := jsonpb.Marshaler{
 		EmitDefaults: emitDefaults,
 		Indent:       "  ",
 		AnyResolver:  resolver,
+		OrigName:     origName,
 	}
 	return marshaler.MarshalToString
 }
@@ -380,6 +381,9 @@ type FormatOptions struct {
 	// It might be useful when the output is piped to another grpcurl process.
 	// FormatText only flag.
 	IncludeTextSeparator bool
+
+	// OrigName specifies whether to use the original protobuf name for fields.
+	OrigName bool
 }
 
 // RequestParserAndFormatter returns a request parser and formatter for the
@@ -394,7 +398,7 @@ func RequestParserAndFormatter(format Format, descSource DescriptorSource, in io
 	case FormatJSON:
 		resolver := AnyResolverFromDescriptorSource(descSource)
 		unmarshaler := jsonpb.Unmarshaler{AnyResolver: resolver, AllowUnknownFields: opts.AllowUnknownFields}
-		return NewJSONRequestParserWithUnmarshaler(in, unmarshaler), NewJSONFormatter(opts.EmitJSONDefaultFields, anyResolverWithFallback{AnyResolver: resolver}), nil
+		return NewJSONRequestParserWithUnmarshaler(in, unmarshaler), NewJSONFormatter(opts.EmitJSONDefaultFields, opts.OrigName, anyResolverWithFallback{AnyResolver: resolver}), nil
 	case FormatText:
 		return NewTextRequestParser(in), NewTextFormatter(opts.IncludeTextSeparator), nil
 	default:


### PR DESCRIPTION
This flag changes the JSON output, keeping the original fields' name as declared in proto, instead of JSON's default lowerCamelCase format

Signed-off-by: Clement Sciascia <clement.sciascia@ovhcloud.com>