### PR TITLE
:rocket: Release grpcurl as common Linux packages

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -38,3 +38,10 @@ archives:
       darwin: osx
     files:
       - LICENSE
+nfpms:
+  - formats:
+      - apk
+      - deb
+      - rpm
+    license: MIT
+    maintainer: FullStory Engineering


### PR DESCRIPTION
This tells `goreleaser` to create apk, deb and rpm packages for every release of `grpcurl`.
This should answer the need express in issue #253 and ease installation of the tool on Linux distribution