### PR TITLE
Use `grpc.reflection.v1.ServerReflection`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This program accepts messages using JSON encoding, which is much more friendly f
 humans and scripts.
 
 With this tool you can also browse the schema for gRPC services, either by querying
-a server that supports [server reflection](https://github.com/grpc/grpc/blob/master/src/proto/grpc/reflection/v1alpha/reflection.proto),
+a server that supports [server reflection](https://github.com/grpc/grpc/blob/master/src/proto/grpc/reflection/v1/reflection.proto),
 by reading proto source files, or by loading in compiled "protoset" files (files that contain
 encoded file [descriptor protos](https://github.com/google/protobuf/blob/master/src/google/protobuf/descriptor.proto)).
 In fact, the way the tool transforms JSON request data into a binary encoded protobuf
@@ -192,7 +192,7 @@ are needed to use them.
 
 ### Server Reflection
 
-Without any additional command-line flags, `grpcurl` will try to use [server reflection](https://github.com/grpc/grpc/blob/master/src/proto/grpc/reflection/v1alpha/reflection.proto).
+Without any additional command-line flags, `grpcurl` will try to use [server reflection](https://github.com/grpc/grpc/blob/master/src/proto/grpc/reflection/v1/reflection.proto).
 
 Examples for how to set up server reflection can be found [here](https://github.com/grpc/grpc/blob/master/doc/server-reflection.md#known-implementations).
 

--- a/cmd/grpcurl/grpcurl.go
+++ b/cmd/grpcurl/grpcurl.go
@@ -21,7 +21,6 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/metadata"
-	reflectpb "google.golang.org/grpc/reflection/grpc_reflection_v1alpha"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/descriptorpb"
 
@@ -508,7 +507,7 @@ func main() {
 		md := grpcurl.MetadataFromHeaders(append(addlHeaders, reflHeaders...))
 		refCtx := metadata.NewOutgoingContext(ctx, md)
 		cc = dial()
-		refClient = grpcreflect.NewClientV1Alpha(refCtx, reflectpb.NewServerReflectionClient(cc))
+		refClient = grpcreflect.NewClientAuto(refCtx, cc)
 		reflSource := grpcurl.DescriptorSourceFromServer(ctx, refClient)
 		if fileSource != nil {
 			descSource = compositeSource{reflSource, fileSource}

--- a/grpcurl_test.go
+++ b/grpcurl_test.go
@@ -21,7 +21,6 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/reflection"
-	reflectpb "google.golang.org/grpc/reflection/grpc_reflection_v1alpha"
 	"google.golang.org/grpc/status"
 
 	. "github.com/fullstorydev/grpcurl"
@@ -82,7 +81,7 @@ func TestMain(m *testing.M) {
 		panic(err)
 	}
 	defer ccReflect.Close()
-	refClient := grpcreflect.NewClientV1Alpha(context.Background(), reflectpb.NewServerReflectionClient(ccReflect))
+	refClient := grpcreflect.NewClientAuto(context.Background(), ccReflect)
 	defer refClient.Reset()
 
 	sourceReflect = DescriptorSourceFromServer(context.Background(), refClient)
@@ -118,7 +117,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestServerDoesNotSupportReflection(t *testing.T) {
-	refClient := grpcreflect.NewClientV1Alpha(context.Background(), reflectpb.NewServerReflectionClient(ccNoReflect))
+	refClient := grpcreflect.NewClientAuto(context.Background(), ccNoReflect)
 	defer refClient.Reset()
 
 	refSource := DescriptorSourceFromServer(context.Background(), refClient)
@@ -216,11 +215,11 @@ func doTestListMethods(t *testing.T, source DescriptorSource, includeReflection 
 
 	if includeReflection {
 		// when using server reflection, we see the TestService as well as the ServerReflection service
-		names, err = ListMethods(source, "grpc.reflection.v1alpha.ServerReflection")
+		names, err = ListMethods(source, "grpc.reflection.v1.ServerReflection")
 		if err != nil {
 			t.Fatalf("failed to list methods for ServerReflection: %v", err)
 		}
-		expected = []string{"grpc.reflection.v1alpha.ServerReflection.ServerReflectionInfo"}
+		expected = []string{"grpc.reflection.v1.ServerReflection.ServerReflectionInfo"}
 	} else {
 		// without reflection, we see all services defined in the same test.proto file, which is the
 		// TestService as well as UnimplementedService


### PR DESCRIPTION
The proper `v1` gRPC reflection has been around for a bit. The "client auto" mechanism still supports falling back to `v1alpha`. Not many support the `v1`, but we should default to it when possible.