### PR TITLE
Run tests on Go 1.21

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,12 @@ jobs:
       - image: cimg/go:1.20
     steps: *simple_job_steps
 
+  build-1-21:
+    working_directory: ~/repo
+    docker:
+      - image: cimg/go:1.21
+    steps: *simple_job_steps
+
 workflows:
   pr-build-test:
     jobs:
@@ -45,3 +51,4 @@ workflows:
       - build-1-18
       - build-1-19
       - build-1-20
+      - build-1-21

--- a/tls_settings_test.go
+++ b/tls_settings_test.go
@@ -213,10 +213,7 @@ func TestBrokenTLS_ClientHasExpiredCert(t *testing.T) {
 		e.Close()
 		t.Fatal("expecting TLS failure setting up server and client")
 	}
-	// Go 1.21 uses "expired certificate" in the error message.
-	// Older Go versions use a simpler "bad certificate".
-	// `runtime.Version()` exists, but we don't want to parse a version String for comparison.
-	if !strings.Contains(err.Error(), "expired certificate") && !strings.Contains(err.Error(), "bad certificate") {
+	if !strings.Contains(err.Error(), "certificate") {
 		t.Fatalf("expecting TLS certificate error, got: %v", err)
 	}
 }

--- a/tls_settings_test.go
+++ b/tls_settings_test.go
@@ -213,7 +213,10 @@ func TestBrokenTLS_ClientHasExpiredCert(t *testing.T) {
 		e.Close()
 		t.Fatal("expecting TLS failure setting up server and client")
 	}
-	if !strings.Contains(err.Error(), "bad certificate") {
+	// Go 1.21 uses "expired certificate" in the error message.
+	// Older Go versions use a simpler "bad certificate".
+	// `runtime.Version()` exists, but we don't want to parse a version String for comparison.
+	if !strings.Contains(err.Error(), "expired certificate") && !strings.Contains(err.Error(), "bad certificate") {
 		t.Fatalf("expecting TLS certificate error, got: %v", err)
 	}
 }


### PR DESCRIPTION
For the most part, there are no breaking changes.

However, the expired certificate is now showing "expired certificate" although previously it showed a simpler "bad certificate" which was hard-coded into the TLS settings test scenario.

Closes #405.