### PR TITLE
Disable CGO for improved compatibility across distros

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,8 @@ errcheck:
 
 .PHONY: test
 test:
-	go test -race ./...
+	# The race detector requires CGO: https://github.com/golang/go/issues/6508
+	CGO_ENABLED=1 go test -race ./...
 
 .tmp/protoc/bin/protoc: ./Makefile ./download_protoc.sh
 	./download_protoc.sh

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ export PATH := $(shell pwd)/.tmp/protoc/bin:$(PATH)
 
 export PROTOC_VERSION := 22.0
 
+# Disable CGO for improved compatibility across distros
+export CGO_ENABLED=0
+
 # TODO: run golint and errcheck, but only to catch *new* violations and
 # decide whether to change code or not (e.g. we need to be able to whitelist
 # violations already in the code). They can be useful to catch errors, but


### PR DESCRIPTION
This PR disables CGO so we recover the same behaviour we had in v1.8.7, where we don't have any dependencies on C libraries expected to be found in the environment, and was raised in https://github.com/fullstorydev/grpcurl/issues/404#issuecomment-1762593336.

Tested by running `make install` before and after the changes and inspecting the produced binary from a Linux machine (Debian in this case).
**Before**
```sh
ldd $(which grpcurl)
	linux-vdso.so.1 (0x00007ffe121e7000)
	libresolv.so.2 => /lib/x86_64-linux-gnu/libresolv.so.2 (0x00007f2346e02000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f2346de0000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f2346c0c000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f2346e26000)
```
**After**
```sh
ldd $(which grpcurl)
	not a dynamic executable
```