### PR TITLE
Update Tarball URL used by Homebrew

### DIFF
--- a/releasing/README.md
+++ b/releasing/README.md
@@ -63,7 +63,7 @@ The last step is to update the Homebrew recipe to use the latest version. First,
 
 ```sh
 # download the source archive from GitHub
-URL=https://github.com/fullstorydev/grpcurl/archive/v2.3.4.tar.gz
+URL=https://github.com/fullstorydev/grpcurl/archive/refs/tags/v2.3.4.tar.gz
 curl -L -o tmp.tgz $URL
 # and compute the SHA
 SHA="$(sha256sum < tmp.tgz | awk '{ print $1 }')"

--- a/releasing/do-release.sh
+++ b/releasing/do-release.sh
@@ -55,7 +55,7 @@ rm VERSION
 
 # Homebrew release
 
-URL="https://github.com/fullstorydev/grpcurl/archive/${VERSION}.tar.gz"
+URL="https://github.com/fullstorydev/grpcurl/archive/refs/tags/${VERSION}.tar.gz"
 curl -L -o tmp.tgz "$URL"
 SHA="$(sha256sum < tmp.tgz | awk '{ print $1 }')"
 rm tmp.tgz


### PR DESCRIPTION
During the `bump-formula-pr` step of the release process, which updates the latest version in Homebrew, I hit the following error:
> line 4, col 3: Use /archive/refs/tags URLs for GitHub tarballs (url is https://github.com/fullstorydev/grpcurl/archive/v1.8.9.tar.gz).
Error: 1 problem in 1 formula detected.

I fixed it by manually changing the URL to https://github.com/fullstorydev/grpcurl/archive/refs/tags/v1.8.9.tar.gz.

It's certainly related to this commit from Homebrew: https://github.com/Homebrew/homebrew-core/commit/2fb3971c8235d3d88d328ebaeddaa57a67188d3a
But I don't have more context on why they decided to change it.