### PR TITLE
Expand the documentation of -max-time to clarify this sets the RPC timeout

### DIFF
--- a/cmd/grpcurl/grpcurl.go
+++ b/cmd/grpcurl/grpcurl.go
@@ -133,9 +133,11 @@ var (
 		is received for this same period then the connection is closed and the
 		operation fails.`))
 	maxTime = flags.Float64("max-time", 0, prettify(`
-		The maximum total time the operation can take, in seconds. This is
-		useful for preventing batch jobs that use grpcurl from hanging due to
-		slow or bad network links or due to incorrect stream method usage.`))
+		The maximum total time the operation can take, in seconds. This sets a
+                timeout on the gRPC context, allowing both client and server to give up
+		after the deadline has past. This is useful for preventing batch jobs
+                that use grpcurl from hanging due to slow or bad network links or due
+		to incorrect stream method usage.`))
 	maxMsgSz = flags.Int("max-msg-sz", 0, prettify(`
 		The maximum encoded size of a response message, in bytes, that grpcurl
 		will accept. If not specified, defaults to 4,194,304 (4 megabytes).`))


### PR DESCRIPTION
I was looking for how to specify a RPC timeout or [deadline](https://grpc.io/docs/guides/deadlines/) via `grpcurl` and tried grepping the `--help` output, but only matched `-connect-timeout`. I found `-max-time` by browsing the codebase looking for `.WithTimeout()` calls. So the motivation of this PR is both to generally clarify the behavior of this flag and also add the words "timeout" and "deadline" specifically to this help text to aid discovery.