### PR TITLE
goreleaser: bump version & add nfmp support

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,12 +29,26 @@ builds:
 
 archives:
   - format: tar.gz
+    name_template: >-
+      {{ .Binary }}_{{ .Version }}_
+      {{- if eq .Os "darwin" }}osx{{ else }}{{ .Os }}{{ end }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}x86_32
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}
     format_overrides:
       - goos: windows
         format: zip
-    replacements:
-      amd64: x86_64
-      386: x86_32
-      darwin: osx
     files:
       - LICENSE
+
+nfpms:
+  - vendor: FullStory
+    homepage: https://github.com/fullstorydev/grpcurl/
+    maintainer: Engineering at FullStory  <fixme@fixme>
+    description: 'Like cURL, but for gRPC: Command-line tool for interacting with gRPC servers'
+    license: MIT
+    id: nfpms
+    formats:
+      - deb
+      - rpm

--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,8 @@ install:
 
 .PHONY: release
 release:
-	@go install github.com/goreleaser/goreleaser@v1.10.0
-	goreleaser release --rm-dist
+	@go install github.com/goreleaser/goreleaser@v1.21.0
+	goreleaser release --clean
 
 .PHONY: docker
 docker:


### PR DESCRIPTION
Updating the config file to support goreleaser 1.21.0 (the last version which doesn't require go1.21)

At the same time, I'm adding support for building the deb & rpm packages, it would make the install easier on those systems if you don't have to manually move a binary

For the deb/rpm packages, I'm keeping the normal naming schemes (darwin / amd64 / ...). But for the .tar.gz files, I've kept the packages names as they were 


# dist folder, on master

```
~> goreleaser release --snapshot --rm-dist
  • starting release...
  • loading config file         file=.goreleaser.yml
  • loading environment variables
  • getting and validating git state
    • building...                   commit=334e3f56ded7e1872c141d121dd7f30a877e140f     latest tag=v1.8.9
    • pipe skipped                  error=disabled during snapshot mode
  • parsing tag
  • setting defaults
  • snapshotting
    • building snapshot...          version=1.8.9-SNAPSHOT-334e3f5
  • checking distribution directory
    • --rm-dist is set, cleaning it up
  • loading go mod information
  • build prerequisites
  • writing effective config file
    • writing                       config=dist/config.yaml
  • building binaries
    • building                      binary=dist/grpcurl_windows_386/grpcurl.exe
    • building                      binary=dist/grpcurl_linux_amd64_v1/grpcurl
    • building                      binary=dist/grpcurl_linux_ppc64le/grpcurl
    • building                      binary=dist/grpcurl_linux_arm64/grpcurl
    • building                      binary=dist/grpcurl_darwin_arm64/grpcurl
    • building                      binary=dist/grpcurl_linux_s390x/grpcurl
    • building                      binary=dist/grpcurl_darwin_amd64_v1/grpcurl
    • building                      binary=dist/grpcurl_linux_386/grpcurl
    • building                      binary=dist/grpcurl_windows_amd64_v1/grpcurl.exe
    • took: 2s
  • archives
    • creating                      archive=dist/grpcurl_1.8.9-SNAPSHOT-334e3f5_osx_arm64.tar.gz
    • creating                      archive=dist/grpcurl_1.8.9-SNAPSHOT-334e3f5_windows_x86_32.zip
    • creating                      archive=dist/grpcurl_1.8.9-SNAPSHOT-334e3f5_osx_x86_64.tar.gz
    • creating                      archive=dist/grpcurl_1.8.9-SNAPSHOT-334e3f5_linux_ppc64le.tar.gz
    • creating                      archive=dist/grpcurl_1.8.9-SNAPSHOT-334e3f5_linux_s390x.tar.gz
    • creating                      archive=dist/grpcurl_1.8.9-SNAPSHOT-334e3f5_linux_arm64.tar.gz
    • creating                      archive=dist/grpcurl_1.8.9-SNAPSHOT-334e3f5_windows_x86_64.zip
    • creating                      archive=dist/grpcurl_1.8.9-SNAPSHOT-334e3f5_linux_x86_64.tar.gz
    • creating                      archive=dist/grpcurl_1.8.9-SNAPSHOT-334e3f5_linux_x86_32.tar.gz
    • took: 3s
  • calculating checksums
  • storing release metadata
    • writing                       file=dist/artifacts.json
    • writing                       file=dist/metadata.json
  • release succeeded after 5s

~> tree dist
dist
├── artifacts.json
├── config.yaml
├── grpcurl_1.8.9-SNAPSHOT-334e3f5_checksums.txt
├── grpcurl_1.8.9-SNAPSHOT-334e3f5_linux_arm64.tar.gz
├── grpcurl_1.8.9-SNAPSHOT-334e3f5_linux_ppc64le.tar.gz
├── grpcurl_1.8.9-SNAPSHOT-334e3f5_linux_s390x.tar.gz
├── grpcurl_1.8.9-SNAPSHOT-334e3f5_linux_x86_32.tar.gz
├── grpcurl_1.8.9-SNAPSHOT-334e3f5_linux_x86_64.tar.gz
├── grpcurl_1.8.9-SNAPSHOT-334e3f5_osx_arm64.tar.gz
├── grpcurl_1.8.9-SNAPSHOT-334e3f5_osx_x86_64.tar.gz
├── grpcurl_1.8.9-SNAPSHOT-334e3f5_windows_x86_32.zip
├── grpcurl_1.8.9-SNAPSHOT-334e3f5_windows_x86_64.zip
├── grpcurl_darwin_amd64_v1
│   └── grpcurl
├── grpcurl_darwin_arm64
│   └── grpcurl
├── grpcurl_linux_386
│   └── grpcurl
├── grpcurl_linux_amd64_v1
│   └── grpcurl
├── grpcurl_linux_arm64
│   └── grpcurl
├── grpcurl_linux_ppc64le
│   └── grpcurl
├── grpcurl_linux_s390x
│   └── grpcurl
├── grpcurl_windows_386
│   └── grpcurl.exe
├── grpcurl_windows_amd64_v1
│   └── grpcurl.exe
└── metadata.json

10 directories, 22 files
```

# dist folder, after those changes

```
~> goreleaser release --snapshot --clean
  • starting release...
  • loading                                          path=.goreleaser.yml
  • skipping announce, publish and validate...
  • loading environment variables
  • getting and validating git state
    • git state                                      commit=c6f0c050d2f3f610f8c6cbabd631722748caffdd branch=goreleaser-nfpms current_tag=v1.8.9 previous_tag=v1.8.8 dirty=true
    • pipe skipped                                   reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
  • snapshotting
    • building snapshot...                           version=1.8.9-SNAPSHOT-c6f0c05
  • checking distribution directory
    • cleaning dist
  • loading go mod information
  • build prerequisites
  • writing effective config file
    • writing                                        config=dist/config.yaml
  • building binaries
    • building                                       binary=dist/grpcurl_windows_386/grpcurl.exe
    • building                                       binary=dist/grpcurl_darwin_arm64/grpcurl
    • building                                       binary=dist/grpcurl_linux_s390x/grpcurl
    • building                                       binary=dist/grpcurl_darwin_amd64_v1/grpcurl
    • building                                       binary=dist/grpcurl_windows_amd64_v1/grpcurl.exe
    • building                                       binary=dist/grpcurl_linux_ppc64le/grpcurl
    • building                                       binary=dist/grpcurl_linux_386/grpcurl
    • building                                       binary=dist/grpcurl_linux_amd64_v1/grpcurl
    • building                                       binary=dist/grpcurl_linux_arm64/grpcurl
    • took: 2s
  • archives
    • creating                                       archive=dist/grpcurl_1.8.9-SNAPSHOT-c6f0c05_windows_x86_64.zip
    • creating                                       archive=dist/grpcurl_1.8.9-SNAPSHOT-c6f0c05_linux_ppc64le.tar.gz
    • creating                                       archive=dist/grpcurl_1.8.9-SNAPSHOT-c6f0c05_osx_arm64.tar.gz
    • creating                                       archive=dist/grpcurl_1.8.9-SNAPSHOT-c6f0c05_linux_s390x.tar.gz
    • creating                                       archive=dist/grpcurl_1.8.9-SNAPSHOT-c6f0c05_linux_arm64.tar.gz
    • creating                                       archive=dist/grpcurl_1.8.9-SNAPSHOT-c6f0c05_linux_x86_32.tar.gz
    • creating                                       archive=dist/grpcurl_1.8.9-SNAPSHOT-c6f0c05_osx_x86_64.tar.gz
    • creating                                       archive=dist/grpcurl_1.8.9-SNAPSHOT-c6f0c05_linux_x86_64.tar.gz
    • creating                                       archive=dist/grpcurl_1.8.9-SNAPSHOT-c6f0c05_windows_x86_32.zip
    • took: 3s
  • linux packages
    • creating                                       package=grpcurl format=rpm arch=arm64 file=dist/grpcurl_1.8.9-SNAPSHOT-c6f0c05_linux_arm64.rpm
    • creating                                       package=grpcurl format=rpm arch=s390x file=dist/grpcurl_1.8.9-SNAPSHOT-c6f0c05_linux_s390x.rpm
    • creating                                       package=grpcurl format=rpm arch=ppc64le file=dist/grpcurl_1.8.9-SNAPSHOT-c6f0c05_linux_ppc64le.rpm
    • creating                                       package=grpcurl format=rpm arch=amd64v1 file=dist/grpcurl_1.8.9-SNAPSHOT-c6f0c05_linux_amd64.rpm
    • creating                                       package=grpcurl format=deb arch=amd64v1 file=dist/grpcurl_1.8.9-SNAPSHOT-c6f0c05_linux_amd64.deb
    • creating                                       package=grpcurl format=deb arch=arm64 file=dist/grpcurl_1.8.9-SNAPSHOT-c6f0c05_linux_arm64.deb
    • creating                                       package=grpcurl format=deb arch=ppc64le file=dist/grpcurl_1.8.9-SNAPSHOT-c6f0c05_linux_ppc64le.deb
    • creating                                       package=grpcurl format=deb arch=386 file=dist/grpcurl_1.8.9-SNAPSHOT-c6f0c05_linux_386.deb
    • creating                                       package=grpcurl format=deb arch=s390x file=dist/grpcurl_1.8.9-SNAPSHOT-c6f0c05_linux_s390x.deb
    • creating                                       package=grpcurl format=rpm arch=386 file=dist/grpcurl_1.8.9-SNAPSHOT-c6f0c05_linux_386.rpm
    • took: 1s
  • calculating checksums
  • storing release metadata
    • writing                                        file=dist/artifacts.json
    • writing                                        file=dist/metadata.json
  • release succeeded after 6s
  • thanks for using goreleaser!



~> tree
dist
├── artifacts.json
├── config.yaml
├── grpcurl_1.8.9-SNAPSHOT-334e3f5_checksums.txt
├── grpcurl_1.8.9-SNAPSHOT-334e3f5_linux_386.deb
├── grpcurl_1.8.9-SNAPSHOT-334e3f5_linux_386.rpm
├── grpcurl_1.8.9-SNAPSHOT-334e3f5_linux_amd64.deb
├── grpcurl_1.8.9-SNAPSHOT-334e3f5_linux_amd64.rpm
├── grpcurl_1.8.9-SNAPSHOT-334e3f5_linux_arm64.deb
├── grpcurl_1.8.9-SNAPSHOT-334e3f5_linux_arm64.rpm
├── grpcurl_1.8.9-SNAPSHOT-334e3f5_linux_arm64.tar.gz
├── grpcurl_1.8.9-SNAPSHOT-334e3f5_linux_ppc64le.deb
├── grpcurl_1.8.9-SNAPSHOT-334e3f5_linux_ppc64le.rpm
├── grpcurl_1.8.9-SNAPSHOT-334e3f5_linux_ppc64le.tar.gz
├── grpcurl_1.8.9-SNAPSHOT-334e3f5_linux_s390x.deb
├── grpcurl_1.8.9-SNAPSHOT-334e3f5_linux_s390x.rpm
├── grpcurl_1.8.9-SNAPSHOT-334e3f5_linux_s390x.tar.gz
├── grpcurl_1.8.9-SNAPSHOT-334e3f5_linux_x86_32.tar.gz
├── grpcurl_1.8.9-SNAPSHOT-334e3f5_linux_x86_64.tar.gz
├── grpcurl_1.8.9-SNAPSHOT-334e3f5_osx_arm64.tar.gz
├── grpcurl_1.8.9-SNAPSHOT-334e3f5_osx_x86_64.tar.gz
├── grpcurl_1.8.9-SNAPSHOT-334e3f5_windows_x86_32.zip
├── grpcurl_1.8.9-SNAPSHOT-334e3f5_windows_x86_64.zip
├── grpcurl_darwin_amd64_v1
│   └── grpcurl
├── grpcurl_darwin_arm64
│   └── grpcurl
├── grpcurl_linux_386
│   └── grpcurl
├── grpcurl_linux_amd64_v1
│   └── grpcurl
├── grpcurl_linux_arm64
│   └── grpcurl
├── grpcurl_linux_ppc64le
│   └── grpcurl
├── grpcurl_linux_s390x
│   └── grpcurl
├── grpcurl_windows_386
│   └── grpcurl.exe
├── grpcurl_windows_amd64_v1
│   └── grpcurl.exe
└── metadata.json
```