### PR TITLE
add encoding flag to allow specifying compression as identity

### DIFF
--- a/cmd/grpcurl/grpcurl.go
+++ b/cmd/grpcurl/grpcurl.go
@@ -164,7 +164,8 @@ var (
 		permitted if they are both set to the same value, to increase backwards
 		compatibility with earlier releases that allowed both to be set).`))
 	reflection = optionalBoolFlag{val: true}
-)
+	encoding = flags.String("encoding", "gzip", prettify(` The value to send for
+		the encoding header. Only 'gzip' and 'identity' are currently supported`)))
 
 func init() {
 	flags.Var(&addlHeaders, "H", prettify(`
@@ -357,6 +358,9 @@ func main() {
 	if *emitDefaults && *format != "json" {
 		warn("The -emit-defaults is only used when using json format.")
 	}
+	if *encoding  != "gzip" && *encoding != "identity" {
+		fail(nil, "The -encoding flag can only be used with the values 'gzip' or 'identity'")
+	}
 
 	args := flags.Args()
 
@@ -474,6 +478,7 @@ func main() {
 		if *maxMsgSz > 0 {
 			opts = append(opts, grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(*maxMsgSz)))
 		}
+		opts = append(opts, grpc.WithDefaultCallOptions(grpc.UseCompressor(*encoding)))
 		var creds credentials.TransportCredentials
 		if *plaintext {
 			if *authority != "" {

--- a/cmd/grpcurl/grpcurl.go
+++ b/cmd/grpcurl/grpcurl.go
@@ -164,8 +164,10 @@ var (
 		permitted if they are both set to the same value, to increase backwards
 		compatibility with earlier releases that allowed both to be set).`))
 	reflection = optionalBoolFlag{val: true}
-	encoding = flags.String("encoding", "gzip", prettify(` The value to send for
-		the encoding header. Only 'gzip' and 'identity' are currently supported`)))
+	encoding   = flags.String("encoding", "gzip", prettify(`
+		The value to send for the grpc-encoding header. Only 'gzip' and 'identity'
+		are currently supported`))
+)
 
 func init() {
 	flags.Var(&addlHeaders, "H", prettify(`
@@ -358,7 +360,7 @@ func main() {
 	if *emitDefaults && *format != "json" {
 		warn("The -emit-defaults is only used when using json format.")
 	}
-	if *encoding  != "gzip" && *encoding != "identity" {
+	if *encoding != "gzip" && *encoding != "identity" {
 		fail(nil, "The -encoding flag can only be used with the values 'gzip' or 'identity'")
 	}
 


### PR DESCRIPTION
Gzip encoding was added in https://github.com/fullstorydev/grpcurl/pull/124. By default the go client will only use this encoder for all requests and not send the `identity` encoder value. I'm testing a dev server that doesn't have gzip encoding implemented yet, so would like to send requests using `identity`. This new optional flag `encoding` sends the expected `grpc-encoding` and `grpc-accept-encoding` headers. In the case of identity, the `grpc-encoding` header only includes `identity`, while the `grpc-accept-encoding` header includes identity and gzip, so the server can still respond with gzip if it chooses when identity is passed.