### PR TITLE
Update Dockerfile to use Go v1.21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18-alpine as builder
+FROM golang:1.21-alpine as builder
 MAINTAINER Fullstory Engineering
 
 # create non-privileged group and user


### PR DESCRIPTION
https://github.com/fullstorydev/grpcurl/pull/453 updated some version that bumped the minimum required Go version to v1.19, but we forgot to update the Dockerfile, which is still using Go v1.18, and broke the release attempt of gRPCurl v1.9.0.

```
#22 [linux/arm64 builder 6/6] RUN go build -o /grpcurl     -ldflags "-w -extldflags "-static" -X "main.version=$(cat VERSION)""     ./cmd/grpcurl
#22 52.36 # google.golang.org/grpc
#22 52.36 /go/pkg/mod/google.golang.org/grpc@v1.61.0/server.go:2182:14: undefined: atomic.Int64
#22 52.36 note: module requires Go 1.19
#22 73.90 # google.golang.org/grpc/balancer/leastrequest
#22 73.90 /go/pkg/mod/google.golang.org/grpc@v1.61.0/balancer/leastrequest/leastrequest.go:83:76: undefined: atomic.Int32
#22 73.90 /go/pkg/mod/google.golang.org/grpc@v1.61.0/balancer/leastrequest/leastrequest.go:95:43: undefined: atomic.Int32
#22 73.90 /go/pkg/mod/google.golang.org/grpc@v1.61.0/balancer/leastrequest/leastrequest.go:111:18: undefined: atomic.Int32
#22 73.90 /go/pkg/mod/google.golang.org/grpc@v1.61.0/balancer/leastrequest/leastrequest.go:129:37: undefined: atomic.Int32
#22 73.90 note: module requires Go 1.19
#22 ERROR: process "/bin/sh -c go build -o /grpcurl     -ldflags \"-w -extldflags \\\"-static\\\" -X \\\"main.version=$(cat VERSION)\\\"\"     ./cmd/grpcurl" did not complete successfully: exit code: 2
```

Tested by building the Docker images for all platforms we support as part of the release process in a Linux machine:
```sh
docker buildx build --platform linux/amd64,linux/s390x,linux/arm64,linux/ppc64le --progress plain --no-cache .
```