### PR TITLE
Add 32bit arm build targets

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,14 +8,23 @@ builds:
     goarch:
       - amd64
       - 386
+      - arm
       - arm64
       - s390x
       - ppc64le
+    goarm:
+      - 5
+      - 6
+      - 7
     ignore:
       - goos: darwin
         goarch: 386
       - goos: windows
         goarch: arm64
+      - goos: darwin
+        goarch: arm
+      - goos: windows
+        goarch: arm
       - goos: darwin
         goarch: s390x
       - goos: windows


### PR DESCRIPTION
I want to use grpcurl on a raspberry pi 0 and therefore I need 32 bit binaries. As this might be interesting for others, I thought, I could just create a PR for it.