### PR TITLE
feat: introduce transparent client side health check

### DIFF
--- a/grpcurl.go
+++ b/grpcurl.go
@@ -28,6 +28,7 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	xdsCredentials "google.golang.org/grpc/credentials/xds"
+	_ "google.golang.org/grpc/health" // import grpc/health to enable transparent client side checking
 	"google.golang.org/grpc/metadata"
 	protov2 "google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/descriptorpb"


### PR DESCRIPTION
gRPC can fetch ServiceConfig by DNS resolver. When ServiceConfig contains health check config, the client should import google.golang.org/grpc/health package to toggle its init() function, which sets the default healthcheck handler function.

Currently, grpcurl doesn't import it, leading service configuration does not take effect, and this MR aims to resolve it.