### PR TITLE
feat: Add functionality to export proto files

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,11 @@ grpcurl -protoset my-protos.bin list
 
 # Using proto sources
 grpcurl -import-path ../protos -proto my-stuff.proto list
+
+# Export proto files
+grpcurl -plaintext -proto-out "out_protos" "192.168.100.1:9200" describe Api.Service
+
+
 ```
 
 The "list" verb also lets you see all methods in a particular service:

--- a/README.md
+++ b/README.md
@@ -160,9 +160,11 @@ grpcurl -protoset my-protos.bin list
 # Using proto sources
 grpcurl -import-path ../protos -proto my-stuff.proto list
 
-# Export proto files
-grpcurl -plaintext -proto-out-dir "out_protos" "192.168.100.1:9200" describe Api.Service
+# Export proto files (use -proto-out-dir to specify the output directory)
+grpcurl -plaintext -proto-out-dir "out_protos" "localhost:8787" describe my.custom.server.Service
 
+# Export protoset file (use -protoset-out to specify the output file)
+grpcurl -plaintext -protoset-out "out.protoset" "localhost:8787" describe my.custom.server.Service
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ grpcurl -protoset my-protos.bin list
 grpcurl -import-path ../protos -proto my-stuff.proto list
 
 # Export proto files
-grpcurl -plaintext -proto-out "out_protos" "192.168.100.1:9200" describe Api.Service
+grpcurl -plaintext -proto-out-dir "out_protos" "192.168.100.1:9200" describe Api.Service
 
 
 ```

--- a/cmd/grpcurl/grpcurl.go
+++ b/cmd/grpcurl/grpcurl.go
@@ -151,7 +151,7 @@ var (
 		file if this option is given. When invoking an RPC and this option is
 		given, the method being invoked and its transitive dependencies will be
 		included in the output file.`))
-	protoOut = flags.String("proto-out", "", prettify(`
+	protoOut = flags.String("proto-out-dir", "", prettify(`
 		The name of a directory where the generated .proto files will be written.
 		With the list and describe verbs, the listed or described elements and
 		their transitive dependencies will be written as .proto files in the

--- a/cmd/grpcurl/grpcurl.go
+++ b/cmd/grpcurl/grpcurl.go
@@ -151,6 +151,14 @@ var (
 		file if this option is given. When invoking an RPC and this option is
 		given, the method being invoked and its transitive dependencies will be
 		included in the output file.`))
+	protoOut = flags.String("proto-out", "", prettify(`
+		The name of a directory where the generated .proto files will be written.
+		With the list and describe verbs, the listed or described elements and
+		their transitive dependencies will be written as .proto files in the
+		specified directory if this option is given. When invoking an RPC and
+		this option is given, the method being invoked and its transitive
+		dependencies will be included in the generated .proto files in the
+		output directory.`))
 	msgTemplate = flags.Bool("msg-template", false, prettify(`
 		When describing messages, show a template of input data.`))
 	verbose = flags.Bool("v", false, prettify(`
@@ -645,6 +653,9 @@ func main() {
 			if err := writeProtoset(descSource, svcs...); err != nil {
 				fail(err, "Failed to write protoset to %s", *protosetOut)
 			}
+			if err := writeProtos(descSource, svcs...); err != nil {
+				fail(err, "Failed to write protos to %s", *protoOut)
+			}
 		} else {
 			methods, err := grpcurl.ListMethods(descSource, symbol)
 			if err != nil {
@@ -659,6 +670,9 @@ func main() {
 			}
 			if err := writeProtoset(descSource, symbol); err != nil {
 				fail(err, "Failed to write protoset to %s", *protosetOut)
+			}
+			if err := writeProtos(descSource, symbol); err != nil {
+				fail(err, "Failed to write protos to %s", *protoOut)
 			}
 		}
 
@@ -763,6 +777,9 @@ func main() {
 		}
 		if err := writeProtoset(descSource, symbols...); err != nil {
 			fail(err, "Failed to write protoset to %s", *protosetOut)
+		}
+		if err := writeProtos(descSource, symbol); err != nil {
+			fail(err, "Failed to write protos to %s", *protoOut)
 		}
 
 	} else {
@@ -921,6 +938,13 @@ func writeProtoset(descSource grpcurl.DescriptorSource, symbols ...string) error
 	}
 	defer f.Close()
 	return grpcurl.WriteProtoset(f, descSource, symbols...)
+}
+
+func writeProtos(descSource grpcurl.DescriptorSource, symbols ...string) error {
+	if *protoOut == "" {
+		return nil
+	}
+	return grpcurl.WriteProtoFiles(*protoOut, descSource, symbols...)
 }
 
 type optionalBoolFlag struct {

--- a/desc_source.go
+++ b/desc_source.go
@@ -322,16 +322,14 @@ func WriteProtoFiles(outProtoDirPath string, descSource DescriptorSource, symbol
 		filePath := filepath.Join(outFilepath, fileName)
 		f, err := os.Create(filePath)
 		if err != nil {
-			if f != nil {
-				_ = f.Close()
-			}
 			return fmt.Errorf("failed to create file %q: %v", filePath, err)
 		}
-		if err := pr.PrintProtoFile(fd, f); err != nil {
+		err = pr.PrintProtoFile(fd, f)
+		if err == nil {
 			_ = f.Close()
+		} else {
 			return fmt.Errorf("failed to write file %q: %v", filePath, err)
 		}
-		_ = f.Close()
 	}
 	return nil
 }

--- a/desc_source.go
+++ b/desc_source.go
@@ -321,10 +321,13 @@ func WriteProtoFiles(outProtoDirPath string, descSource DescriptorSource, symbol
 		fileName := filepath.Base(fdFQName)
 		filePath := filepath.Join(outFilepath, fileName)
 		f, err := os.Create(filePath)
-		defer f.Close()
 		if err != nil {
+			if f != nil {
+				_ = f.Close()
+			}
 			return fmt.Errorf("failed to create file %q: %v", filePath, err)
 		}
+		_ = f.Close()
 		if err := pr.PrintProtoFile(fd, f); err != nil {
 			return fmt.Errorf("failed to write file %q: %v", filePath, err)
 		}

--- a/desc_source.go
+++ b/desc_source.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/jhump/protoreflect/desc/protoprint"
 	"io"
 	"os"
 	"path/filepath"
@@ -13,6 +12,7 @@ import (
 	"github.com/golang/protobuf/proto" //lint:ignore SA1019 we have to import this because it appears in exported API
 	"github.com/jhump/protoreflect/desc"
 	"github.com/jhump/protoreflect/desc/protoparse"
+	"github.com/jhump/protoreflect/desc/protoprint"
 	"github.com/jhump/protoreflect/dynamic"
 	"github.com/jhump/protoreflect/grpcreflect"
 	"google.golang.org/grpc/codes"

--- a/desc_source.go
+++ b/desc_source.go
@@ -320,22 +320,19 @@ func WriteProtoFiles(outProtoDirPath string, descSource DescriptorSource, symbol
 }
 
 func writeProtoFile(outProtoDirPath string, fd *desc.FileDescriptor, pr *protoprint.Printer) error {
-	fdFQName := fd.GetFullyQualifiedName()
-	dirPath := filepath.Dir(fdFQName)
-	outFilepath := filepath.Join(outProtoDirPath, dirPath)
-	if err := os.MkdirAll(outFilepath, 0755); err != nil {
-		return fmt.Errorf("failed to create directory %q: %v", outFilepath, err)
+	outFile := filepath.Join(outProtoDirPath, fd.GetFullyQualifiedName())
+	outDir := filepath.Dir(outFile)
+	if err := os.MkdirAll(outDir, 0777); err != nil {
+		return fmt.Errorf("failed to create directory %q: %w", outDir, err)
 	}
-	fileName := filepath.Base(fdFQName)
-	filePath := filepath.Join(outFilepath, fileName)
 
-	f, err := os.Create(filePath)
+	f, err := os.Create(outFile)
 	if err != nil {
-		return fmt.Errorf("failed to create proto file: %v", err)
+		return fmt.Errorf("failed to create proto file %q: %w", outFile, err)
 	}
 	defer f.Close()
 	if err := pr.PrintProtoFile(fd, f); err != nil {
-		return fmt.Errorf("failed to write proto file: %v", err)
+		return fmt.Errorf("failed to write proto file %q: %w", outFile, err)
 	}
 	return nil
 }

--- a/desc_source.go
+++ b/desc_source.go
@@ -327,10 +327,11 @@ func WriteProtoFiles(outProtoDirPath string, descSource DescriptorSource, symbol
 			}
 			return fmt.Errorf("failed to create file %q: %v", filePath, err)
 		}
-		_ = f.Close()
 		if err := pr.PrintProtoFile(fd, f); err != nil {
+			_ = f.Close()
 			return fmt.Errorf("failed to write file %q: %v", filePath, err)
 		}
+		_ = f.Close()
 	}
 	return nil
 }


### PR DESCRIPTION
**Feature Description:**

Add a new option **--proto-out-dir** to grpcurl that allows users to generate .proto files for listed, described, or invoked elements and their transitive dependencies.

**Functionality:**

When using the list and describe verbs, the listed or described elements and their transitive dependencies will be written as .proto files in the specified directory.

**Proposed Implementation:**
Add a new flag:
```go
protoOut = flags.String("proto-out-dir", "", "The name of a directory where the generated .proto files will be written.")
```

**Use Case:**
This feature will be useful for users who need to generate .proto files from gRPC services, especially when working with services that don't have readily available .proto files or when dealing with dynamically generated services.

Tested with the starlink gRPC server.

<img width="894" alt="image" src="https://github.com/fullstorydev/grpcurl/assets/1043061/8d2e7147-f9b8-45eb-b347-88d3b0eb4c16">

TEST: OK 

<img width="813" alt="image" src="https://github.com/fullstorydev/grpcurl/assets/1043061/22713a85-fa45-4366-8181-b4e522dde6dc">

closes #474 
closes #206  