### PR TITLE
Allow missing extension ranges since not all messages are extended

### DIFF
--- a/grpcurl.go
+++ b/grpcurl.go
@@ -310,7 +310,7 @@ func fetchAllExtensions(source DescriptorSource, ext *dynamic.ExtensionRegistry,
 	if len(md.GetExtensionRanges()) > 0 {
 		fds, err := source.AllExtensionsForType(msgTypeName)
 		if err != nil {
-			return fmt.Errorf("failed to query for extensions of type %s: %v", msgTypeName, err)
+			fds = []*desc.FieldDescriptor{}
 		}
 		for _, fd := range fds {
 			if err := ext.AddExtension(fd); err != nil {


### PR DESCRIPTION
## Background & Problem

I'm working on a java grpc service that have a field of type `google.protobuf.DescriptorProto` from [descriptor.proto](https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/descriptor.proto) in the response message. 

When running `grpcurl`, I'm hit with the following fatal error message:

```
Error invoking method "MyDescriptorMethod": error resolving server extensions for message MyDescriptorMethodResponse: failed to query for extensions of type google.protobuf.FeatureSet: Message not found: google.protobuf.FeatureSet
```

If I allow the grpcurl to continue past that error, I'm also getting errors on `google.protobuf.ExtensionRangeOptions`.

For context, here's the snippet where [FeatureSet](https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/descriptor.proto#L1001-L1124) is reserving extensions:

```protobuf
message FeatureSet {
  ...
  extensions 1000;  // for Protobuf C++
  extensions 1001;  // for Protobuf Java
  extensions 1002;  // for Protobuf Go

  extensions 9990;  // for deprecated Java Proto1

  extensions 9995 to 9999;  // For internal testing
  extensions 10000;         // for https://github.com/bufbuild/protobuf-es
}
```

### Difference in grpcurl and java-grpc

`grpcurl` calls `desc.MessageDescriptor.GetExtensionRanges()`, which seems to return a list of the extension ranges above. However, java-grpc is calling `FileDescriptor.getExtensions()` [ref](https://github.com/grpc/grpc-java/blob/master/services/src/main/java/io/grpc/protobuf/services/ProtoReflectionServiceV1.java#L489). From what I can tell, `getExtensions()` is _only_ returning a value if the message in question is extended by _another_ message. 

For example, there are multiple other messages in `descriptor.proto` that also declare extension ranges in the same way, that are not failing. However, for those, there are _other_ messages extending the message. See [envoy/annotations/deprecation.proto](https://buf.build/envoyproxy/envoy/file/main:envoy/annotations/deprecation.proto#L17):

```protobuf
extend google.protobuf.FieldOptions {
  bool disallowed_by_default = [18]
  string deprecated_at_minor_version = 157299826;
}
```

## Solution?

So it seems like, for `fetchAllExtensions` to properly work, all messages with an extension range declared _must_ have another message extending that message? That feels like a thing that should not necessarily always be true. Rather we would allow no extensions to be found on the message, since that is expected if there are only extension ranges declared (and no other messages extending it).

Please advise if this solution makes sense, or if you think it's rather grpc-java that should update their reflection service to account for non-extended messages.

Thanks for a great tool!
