### PR TITLE
Snap: strict confinement, stable grade and docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dist/
 .idea/
 VERSION
 .tmp/
+*.snap

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # gRPCurl
 [![Build Status](https://circleci.com/gh/fullstorydev/grpcurl/tree/master.svg?style=svg)](https://circleci.com/gh/fullstorydev/grpcurl/tree/master)
 [![Go Report Card](https://goreportcard.com/badge/github.com/fullstorydev/grpcurl)](https://goreportcard.com/report/github.com/fullstorydev/grpcurl)
+[![Snap Release Status](https://snapcraft.io/grpcurl/badge.svg)](https://snapcraft.io/grpcurl)
 
 `grpcurl` is a command-line tool that lets you interact with gRPC servers. It's
 basically `curl` for gRPC servers.
@@ -78,6 +79,12 @@ of environments, including Windows and myriad Linux distributions.
 
 You can see more details and the full list of other packages for `grpcurl` at _repology.org_:
 https://repology.org/project/grpcurl/information
+
+### Snap
+
+You can install `grpcurl` using the snap package:
+
+`snap install grpcurl`
 
 ### From Source
 If you already have the [Go SDK](https://golang.org/doc/install) installed, you can use the `go`

--- a/snap/README.md
+++ b/snap/README.md
@@ -1,0 +1,23 @@
+# packing and releasing
+To pack the current branch to a snap package:
+
+`snapcraft pack`
+
+To install the package locally:
+
+`snap install ./grpcurl_v[version tag]_amd64.snap --devmode`
+
+To upload the snap to the edge channel:
+
+`snapcraft upload --release edge ./grpcurl_v[version tag]_amd64.snap`
+
+(you need to own the package name registration for this!)
+
+# ownership
+The snap's current owner is `pietro.pasotti@canonical.com`; who is very happy to support with maintaining the snap distribution and/or transfer its ownership to the developers.
+
+Please reach out to me for questions regarding the snap; including:
+- adding support for other architectures
+- automating the release
+
+Cheers and thanks for the awesome tool!

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,7 +8,7 @@ description: |
   It's basically curl for gRPC servers.
 
 grade: devel
-confinement: devmode
+confinement: strict
 
 apps:
   grpcurl:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,6 +10,7 @@ description: |
 
 grade: stable
 confinement: strict
+license: MIT
 
 apps:
   grpcurl:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -7,7 +7,7 @@ description: |
   grpcurl is a command-line tool that lets you interact with gRPC servers. 
   It's basically curl for gRPC servers.
 
-grade: devel
+grade: stable
 confinement: strict
 
 apps:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,29 @@
+name: grpcurl
+base: core24
+version: '0.1'
+summary: grpcurl is a command-line tool that lets you interact with gRPC servers.
+
+description: |
+  grpcurl is a command-line tool that lets you interact with gRPC servers. 
+  It's basically curl for gRPC servers.
+
+grade: devel
+confinement: devmode
+
+apps:
+  grpcurl:
+    command: grpcurl
+    plugs:
+      - network
+
+parts:
+  grpcurl:
+    plugin: go
+    build-snaps: [go/latest/stable]
+    source: https://github.com/fullstorydev/grpcurl
+    source-type: git
+    override-build: |
+      go build -o $CRAFT_PART_INSTALL/grpcurl ./cmd/grpcurl/grpcurl.go
+      
+      # adjust the permissions
+      chmod 0755 $CRAFT_PART_INSTALL/grpcurl

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,7 @@
 name: grpcurl
 base: core24
-version: '0.1'
+# allow grpcurl part to call craftctl set-version
+adopt-info: grpcurl
 summary: grpcurl is a command-line tool that lets you interact with gRPC servers.
 
 description: |
@@ -23,6 +24,9 @@ parts:
     source: https://github.com/fullstorydev/grpcurl
     source-type: git
     override-build: |
+      tag="$(git describe --tags --abbrev=0)"
+      craftctl set version="$tag"
+
       go build -o $CRAFT_PART_INSTALL/grpcurl ./cmd/grpcurl/grpcurl.go
       
       # adjust the permissions


### PR DESCRIPTION
Hi!
On top of #512, I am hereby:
- locking down the confinement of the snap to `classic`, this means that the installer has [certain strong guarantees](https://snapcraft.io/docs/snap-confinement) that the package won't do undesired things to their system
- upgrading the grade to `stable`, so that the snap can be released and installed by anyone
- adding a badge to the readme and a note about installing the snap
- a readme so any dev working on this project knows what the snapcraft.yaml is about and how to maintain it

I have released a snap for the current 1.9.3 tag

![image](https://github.com/user-attachments/assets/718ef509-285b-451e-8454-16b5bb9acdfc)

This means that if you run `sudo snap install grpcurl --channel edge`, you'll have grpcurl 1.9.3 within seconds up and running in your machine!
Which IMHO is great.

The next step, if you're interested, would be to set up some automation so that every time you create a new release, we also release a new snap to the edge channel (and what previously was on edge can be promoted up towards a stable channel).