### PR TITLE
feat: add arm snap build

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -12,6 +12,19 @@ grade: stable
 confinement: strict
 license: MIT
 
+platforms:
+  amd64:
+    build-on:
+      - amd64
+    build-for:
+      - amd64
+  arm64:
+    build-on:
+      - amd64
+      - arm64
+    build-for:
+      - arm64
+
 apps:
   grpcurl:
     command: grpcurl


### PR DESCRIPTION
This PR enables arm64 builds for the snap package.

If you'd like me to enable more architectures, do let me know! 