### PR TITLE
refactor: use strings.Builder to improve performance

### DIFF
--- a/cmd/grpcurl/grpcurl.go
+++ b/cmd/grpcurl/grpcurl.go
@@ -848,11 +848,11 @@ func main() {
 }
 
 func dumpTiming(td *timingData, lvl int) {
-	ind := ""
+	var ind strings.Builder
 	for x := 0; x < lvl; x++ {
-		ind += "  "
+		ind.WriteString("  ")
 	}
-	fmt.Printf("%s%s: %s\n", ind, td.Title, td.Value)
+	fmt.Printf("%s%s: %s\n", ind.String(), td.Title, td.Value)
 	for _, sd := range td.Sub {
 		dumpTiming(sd, lvl+1)
 	}


### PR DESCRIPTION
strings.Builder has fewer memory allocations and better performance.
More info: [golang/go#75190](https://github.com/golang/go/issues/75190)