### PR TITLE
Add Windows Arm64 release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,8 +19,6 @@ builds:
     ignore:
       - goos: darwin
         goarch: 386
-      - goos: windows
-        goarch: arm64
       - goos: darwin
         goarch: arm
       - goos: windows


### PR DESCRIPTION
Try to add Windows Arm64 releases by removing the `ignore` entry for that combination.

Windows Arm64 should be supported starting with [Go 1.17](https://tip.golang.org/doc/go1.17#windows).

Fixes #541