### PR TITLE
Release container for armv7

### DIFF
--- a/releasing/do-release.sh
+++ b/releasing/do-release.sh
@@ -49,8 +49,8 @@ $PREFIX docker run --privileged --rm tonistiigi/binfmt:qemu-v6.1.0 --install all
 export DOCKER_CLI_EXPERIMENTAL=enabled
 $PREFIX docker buildx create --use --name multiarch-builder --node multiarch-builder0
 # push to docker hub, both the given version as a tag and for "latest" tag
-$PREFIX docker buildx build --platform linux/amd64,linux/s390x,linux/arm64,linux/ppc64le --tag fullstorydev/grpcurl:${VERSION} --tag fullstorydev/grpcurl:latest --push --progress plain --no-cache .
-$PREFIX docker buildx build --platform linux/amd64,linux/s390x,linux/arm64,linux/ppc64le --tag fullstorydev/grpcurl:${VERSION}-alpine --tag fullstorydev/grpcurl:latest-alpine --push --progress plain --no-cache --target alpine .
+$PREFIX docker buildx build --platform linux/amd64,linux/s390x,linux/arm64,linux/ppc64le,linux/arm/v7 --tag fullstorydev/grpcurl:${VERSION} --tag fullstorydev/grpcurl:latest --push --progress plain --no-cache .
+$PREFIX docker buildx build --platform linux/amd64,linux/s390x,linux/arm64,linux/ppc64le,linux/arm/v7 --tag fullstorydev/grpcurl:${VERSION}-alpine --tag fullstorydev/grpcurl:latest-alpine --push --progress plain --no-cache --target alpine .
 rm VERSION
 
 # Homebrew release


### PR DESCRIPTION
Add `linux/arm/v7` platform variant to release scripts docker buildx args.

Closes #551 