### PR TITLE
refactor: remove obsolete // +build tag

### DIFF
--- a/cmd/grpcurl/unix.go
+++ b/cmd/grpcurl/unix.go
@@ -1,5 +1,4 @@
 //go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris || windows
-// +build darwin dragonfly freebsd linux netbsd openbsd solaris windows
 
 package main
 

--- a/internal/testing/cmd/testserver/unix.go
+++ b/internal/testing/cmd/testserver/unix.go
@@ -1,5 +1,4 @@
 //go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
-// +build darwin dragonfly freebsd linux netbsd openbsd solaris
 
 package main
 


### PR DESCRIPTION
From Go 1.17, the preferred syntax for build constraints is `//go:build`,
which replaces the old `// +build` form. The old style is now considered
deprecated but still supported for backward compatibility.

This change removes the obsolete `// +build xxx` line, keeping only the
modern `//go:build xxx` directive.

More info: https://github.com/golang/go/issues/41184 and https://go.dev/doc/go1.17#build-lines