### PR TITLE
fix xds credentials being silently ignored

### DIFF
--- a/grpcurl.go
+++ b/grpcurl.go
@@ -618,7 +618,7 @@ func BlockingDial(ctx context.Context, network, address string, creds credential
 
 	var err error
 	if strings.HasPrefix(address, "xds://") {
-		// The xds:/// prefix is used to signal to the gRPC client to use an xDS server to resolve the
+		// The xds:// prefix is used to signal to the gRPC client to use an xDS server to resolve the
 		// target. The relevant credentials will be automatically pulled from the GRPC_XDS_BOOTSTRAP or
 		// GRPC_XDS_BOOTSTRAP_CONFIG env vars.
 		creds, err = xdsCredentials.NewClientCredentials(xdsCredentials.ClientOptions{FallbackCreds: creds})

--- a/grpcurl.go
+++ b/grpcurl.go
@@ -617,7 +617,7 @@ func BlockingDial(ctx context.Context, network, address string, creds credential
 	}
 
 	var err error
-	if strings.HasPrefix(address, "xds:///") {
+	if strings.HasPrefix(address, "xds://") {
 		// The xds:/// prefix is used to signal to the gRPC client to use an xDS server to resolve the
 		// target. The relevant credentials will be automatically pulled from the GRPC_XDS_BOOTSTRAP or
 		// GRPC_XDS_BOOTSTRAP_CONFIG env vars.
@@ -736,4 +736,19 @@ func (c *errSignalingCreds) ClientHandshake(ctx context.Context, addr string, ra
 		c.writeResult(err)
 	}
 	return conn, auth, err
+}
+
+// UsesXDS forwards the optional UsesXDS marker of the wrapped credentials. The
+// xDS credentials returned for "xds://" targets implement this method, and
+// grpc-go's cds balancer relies on a type assertion for it to decide whether to
+// apply the security configuration (e.g. UpstreamTlsContext) delivered by the
+// management server. Because errSignalingCreds embeds the TransportCredentials
+// interface, that extra method is not promoted automatically, so we forward it
+// explicitly. Without this, xDS-supplied mTLS is silently ignored and the
+// connection falls back to the plain credentials.
+func (c *errSignalingCreds) UsesXDS() bool {
+	if x, ok := c.TransportCredentials.(interface{ UsesXDS() bool }); ok {
+		return x.UsesXDS()
+	}
+	return false
 }


### PR DESCRIPTION
Fixes #565

Before change:
```
GRPC_XDS_BOOTSTRAP=/tmp/b.json go run cmd/grpcurl/grpcurl.go xds:///<target service> list
Failed to dial target host "xds:///<target service>": tls: failed to verify certificate: x509: certificate is not valid for any names, but wanted to match <target service>
exit status 1
```

After change:
```
GRPC_XDS_BOOTSTRAP=/tmp/b.json go run cmd/grpcurl/grpcurl.go xds:///<target service> list
grpc.health.v1.Health
grpc.reflection.v1.ServerReflection
grpc.reflection.v1alpha.ServerReflection
...
```