### PR TITLE
Add tests to cover blocking dial and proxy behavior

### DIFF
--- a/blocking_dial_resolver_test.go
+++ b/blocking_dial_resolver_test.go
@@ -1,0 +1,81 @@
+package grpcurl_test
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	. "github.com/fullstorydev/grpcurl"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/resolver"
+	"google.golang.org/grpc/resolver/manual"
+)
+
+func TestBlockingDialDNSWithoutProxy(t *testing.T) {
+	address := "dns:///" + startTCPServer(t)
+	for _, network := range []string{"", "tcp"} {
+		t.Run("network="+network, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), dialTimeout)
+			defer cancel()
+			cc, err := BlockingDial(ctx, network, address, nil, grpc.WithNoProxy())
+			if err != nil {
+				t.Fatalf("BlockingDial(%q, %q) failed: %v", network, address, err)
+			}
+			defer cc.Close()
+
+			// Canceling the dial context must not close a returned connection.
+			cancel()
+			simpleTest(t, cc)
+		})
+	}
+}
+
+func TestBlockingDialCustomDNSResolver(t *testing.T) {
+	backend := startTCPServer(t)
+	const target = "dns://nameserver.invalid/grpcurl-resolver-test.invalid:443"
+	built := make(chan resolver.Target, 1)
+	dialed := make(chan string, 1)
+	r := manual.NewBuilderWithScheme("dns")
+	r.BuildCallback = func(target resolver.Target, _ resolver.ClientConn, _ resolver.BuildOptions) {
+		select {
+		case built <- target:
+		default:
+		}
+	}
+	r.InitialState(resolver.State{Addresses: []resolver.Address{{Addr: backend}}})
+	dialer := func(ctx context.Context, address string) (net.Conn, error) {
+		select {
+		case dialed <- address:
+		default:
+		}
+		return (&net.Dialer{}).DialContext(ctx, "tcp", address)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), dialTimeout)
+	defer cancel()
+	cc, err := BlockingDial(ctx, "", target, nil,
+		grpc.WithResolvers(r), grpc.WithContextDialer(dialer), grpc.WithNoProxy())
+	if err != nil {
+		t.Fatalf("BlockingDial(%q) failed: %v", target, err)
+	}
+	defer cc.Close()
+
+	// Rewriting dns targets to passthrough would bypass the caller's resolver
+	// and pass the unresolvable logical target to the custom dialer.
+	select {
+	case actual := <-built:
+		if actual.URL.String() != target {
+			t.Errorf("resolver target = %q, want %q", actual.URL.String(), target)
+		}
+	default:
+		t.Fatal("custom DNS resolver was not used")
+	}
+	select {
+	case actual := <-dialed:
+		if actual != backend {
+			t.Errorf("dialer address = %q, want resolved backend %q", actual, backend)
+		}
+	default:
+		t.Fatal("custom dialer was not used")
+	}
+	simpleTest(t, cc)
+}

--- a/blocking_dial_test.go
+++ b/blocking_dial_test.go
@@ -1,0 +1,230 @@
+package grpcurl_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	. "github.com/fullstorydev/grpcurl"
+	grpcurl_testing "github.com/fullstorydev/grpcurl/internal/testing"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/backoff"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+// dialTimeout gives successful connections ample time to become ready.
+const dialTimeout = 10 * time.Second
+
+// Failed connections currently retry until their context expires. Keep these
+// deadlines short so testing that behavior does not slow down the suite.
+const dialFailureTimeout = 250 * time.Millisecond
+
+// startTCPServer starts a gRPC server on a loopback TCP port and returns its
+// host:port address. The server is stopped when the test finishes.
+func startTCPServer(t *testing.T) string {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	serveOn(t, l)
+	return l.Addr().String()
+}
+
+// serveOn registers the test service on a gRPC server serving the given
+// listener, and arranges for it to be stopped when the test finishes.
+func serveOn(t *testing.T, l net.Listener) *grpc.Server {
+	t.Helper()
+	svr := grpc.NewServer()
+	grpcurl_testing.RegisterTestServiceServer(svr, grpcurl_testing.TestServer{})
+	go svr.Serve(l)
+	t.Cleanup(svr.Stop)
+	return svr
+}
+
+// unusedTCPPort returns a loopback address that nothing is listening on, by
+// binding a port and immediately releasing it.
+func unusedTCPPort(t *testing.T) string {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	addr := l.Addr().String()
+	if err := l.Close(); err != nil {
+		t.Fatalf("failed to close listener: %v", err)
+	}
+	return addr
+}
+
+// assertDialSucceeds dials the address and verifies the connection works by
+// issuing an RPC over it.
+func assertDialSucceeds(t *testing.T, network, address string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), dialTimeout)
+	defer cancel()
+
+	cc, err := BlockingDial(ctx, network, address, nil)
+	if err != nil {
+		t.Fatalf("BlockingDial(%q, %q) failed: %v", network, address, err)
+	}
+	defer cc.Close()
+
+	simpleTest(t, cc)
+}
+
+// assertDialTimesOut records current behavior, not the desired behavior, for
+// failures before the transport handshake.
+// TODO: https://github.com/fullstorydev/grpcurl/issues/581
+// Replace the timeout assertion with a check for prompt failure that preserves
+// the underlying dial error once error reporting is fixed.
+func assertDialTimesOut(t *testing.T, network, address string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), dialFailureTimeout)
+	defer cancel()
+
+	cc, err := BlockingDial(ctx, network, address, nil)
+	if cc != nil {
+		cc.Close()
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("BlockingDial(%q, %q) error = %q, want it to wrap %v",
+			network, address, err, context.DeadlineExceeded)
+	}
+}
+
+func TestBlockingDialTCP(t *testing.T) {
+	addr := startTCPServer(t)
+
+	// The empty network is what the command line uses, so it is the most
+	// important case to cover; "tcp" is supported for callers of the library.
+	for _, network := range []string{"", "tcp"} {
+		t.Run(fmt.Sprintf("network=%q", network), func(t *testing.T) {
+			assertDialSucceeds(t, network, addr)
+		})
+	}
+}
+
+func TestBlockingDialTCPConnectionRefused(t *testing.T) {
+	// TODO: https://github.com/fullstorydev/grpcurl/issues/581
+	// A refused connection should fail promptly with the underlying
+	// "connection refused" error. For now, record the generic timeout.
+	addr := unusedTCPPort(t)
+
+	for _, network := range []string{"", "tcp"} {
+		t.Run(fmt.Sprintf("network=%q", network), func(t *testing.T) {
+			assertDialTimesOut(t, network, addr)
+		})
+	}
+}
+
+type dialError struct{ temporary bool }
+
+func (e dialError) Error() string   { return "injected dial failure" }
+func (e dialError) Temporary() bool { return e.temporary }
+
+func fastDialBackoff() grpc.DialOption {
+	return grpc.WithConnectParams(grpc.ConnectParams{
+		Backoff: backoff.Config{
+			BaseDelay:  10 * time.Millisecond,
+			Multiplier: 1,
+			MaxDelay:   10 * time.Millisecond,
+		},
+		MinConnectTimeout: time.Second,
+	})
+}
+
+func TestBlockingDialRetries(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		temporary bool
+		override  bool
+	}{
+		{name: "temporary", temporary: true},
+		// TODO: https://github.com/fullstorydev/grpcurl/issues/581
+		// Without a caller override, a permanent error should be returned on
+		// the first attempt. This case currently records retrying to success.
+		{name: "permanent"},
+		{name: "permanent with caller override", override: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			listener := bufconn.Listen(1024 * 1024)
+			serveOn(t, listener)
+			var attempts atomic.Int32
+			wantErr := dialError{temporary: tc.temporary}
+			opts := []grpc.DialOption{
+				fastDialBackoff(),
+				grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+					if attempts.Add(1) == 1 {
+						return nil, wantErr
+					}
+					return listener.DialContext(ctx)
+				}),
+			}
+			if tc.override {
+				opts = append(opts, grpc.FailOnNonTempDialError(false))
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), dialTimeout)
+			defer cancel()
+			cc, err := BlockingDial(ctx, "", "passthrough:///retry-test", nil, opts...)
+			// NewClient currently retries both temporary and permanent errors;
+			// FailOnNonTempDialError(false) is also accepted from library callers.
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer cc.Close()
+			if attempts.Load() != 2 {
+				t.Errorf("dial attempts = %d, want 2", attempts.Load())
+			}
+			cancel()
+			// A successful connection must outlive its dial context.
+			simpleTest(t, cc)
+		})
+	}
+}
+
+func TestBlockingDialReconnect(t *testing.T) {
+	first := bufconn.Listen(1024 * 1024)
+	second := bufconn.Listen(1024 * 1024)
+	firstServer := serveOn(t, first)
+	serveOn(t, second)
+	var active atomic.Pointer[bufconn.Listener]
+	active.Store(first)
+	ctx, cancel := context.WithTimeout(context.Background(), dialTimeout)
+	defer cancel()
+	cc, err := BlockingDial(ctx, "", "passthrough:///reconnect-test", nil,
+		fastDialBackoff(),
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return active.Load().DialContext(ctx)
+		}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cc.Close()
+	cancel()
+	simpleTest(t, cc)
+	active.Store(second)
+	firstServer.Stop()
+	simpleTest(t, cc)
+}
+
+func TestBlockingDialTCPNetworkRejectsUnixAddress(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), dialTimeout)
+	defer cancel()
+
+	cc, err := BlockingDial(ctx, "tcp", "unix:///tmp/does-not-exist.sock", nil)
+	if cc != nil {
+		cc.Close()
+	}
+	if err == nil {
+		t.Fatal("BlockingDial with tcp network and unix address succeeded, expected it to fail")
+	}
+	if !strings.Contains(err.Error(), "cannot use unix address") {
+		t.Errorf("error = %q, want it to contain %q", err, "cannot use unix address")
+	}
+}

--- a/blocking_dial_unix_test.go
+++ b/blocking_dial_unix_test.go
@@ -1,0 +1,64 @@
+//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+
+package grpcurl_test
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// tempSocketPath returns a path suitable for a unix domain socket. It uses a
+// short temporary directory rather than t.TempDir() because socket paths are
+// limited to around 100 characters, and t.TempDir() embeds the test name.
+func tempSocketPath(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "grpcurl")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	return filepath.Join(dir, "s.sock")
+}
+
+// startUnixServer starts a gRPC server listening on a unix domain socket and
+// returns the socket path. The server is stopped when the test finishes.
+func startUnixServer(t *testing.T) string {
+	t.Helper()
+	path := tempSocketPath(t)
+	l, err := net.Listen("unix", path)
+	if err != nil {
+		t.Fatalf("failed to listen on unix socket: %v", err)
+	}
+	serveOn(t, l)
+	return path
+}
+
+func TestBlockingDialUnix(t *testing.T) {
+	// The command line prepends "unix://" to the target and passes an empty
+	// network, so that combination is the one that matters most. A bare path
+	// with network "unix" is also supported, for backwards compatibility with
+	// https://github.com/fullstorydev/grpcurl/pull/480
+	t.Run("network= with unix:// address", func(t *testing.T) {
+		assertDialSucceeds(t, "", "unix://"+startUnixServer(t))
+	})
+	t.Run("network=unix with bare path", func(t *testing.T) {
+		assertDialSucceeds(t, "unix", startUnixServer(t))
+	})
+}
+
+func TestBlockingDialUnixSocketMissing(t *testing.T) {
+	// TODO: https://github.com/fullstorydev/grpcurl/issues/581
+	// A missing socket should fail promptly with "no such file or directory".
+	// The socket is never created, but BlockingDial currently retries until
+	// the context expires and returns the generic timeout instead.
+	path := tempSocketPath(t)
+
+	t.Run("network= with unix:// address", func(t *testing.T) {
+		assertDialTimesOut(t, "", "unix://"+path)
+	})
+	t.Run("network=unix with bare path", func(t *testing.T) {
+		assertDialTimesOut(t, "unix", path)
+	})
+}

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -1,0 +1,249 @@
+package grpcurl_test
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	. "github.com/fullstorydev/grpcurl"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/resolver"
+	"google.golang.org/grpc/resolver/manual"
+)
+
+// proxyChildEnv marks the re-executed child process that runs the body of
+// TestProxySupport.
+const proxyChildEnv = "GRPCURL_TEST_PROXY_CHILD"
+
+// proxyTarget is the address the client is asked to dial. It must be a name
+// rather than an IP, and it must not resolve:
+//
+//   - A loopback address would never be proxied at all. net/http excludes
+//     "localhost" and any loopback IP from proxying, so the proxy would be
+//     skipped and the test would pass without proving anything.
+//   - Because the name never resolves, the RPC can only succeed by way of the
+//     proxy. A regression that bypasses the proxy cannot accidentally pass by
+//     connecting directly.
+//
+// The .invalid TLD is reserved by RFC 2606 and is guaranteed not to resolve.
+const proxyTarget = "grpcurl-proxy-test.invalid:443"
+
+// TestProxySupport verifies that a dial honors the HTTPS_PROXY environment
+// variable, by routing it through a local HTTP CONNECT proxy.
+//
+// This guards the fix in https://github.com/fullstorydev/grpcurl/pull/480,
+// which removed a custom dialer precisely so that grpc-go's own proxy support
+// would be used. grpc-go treats grpc.WithContextDialer as an opt-out of proxy
+// support: when a custom dialer is set it skips the delegating resolver that
+// implements proxying. Reintroducing a custom dialer therefore silently
+// disables proxies, which nothing else in this suite would catch.
+//
+// The test runs in a re-executed child process. net/http resolves the proxy
+// environment once per process and caches it in a sync.Once, so any earlier
+// dial in this test binary would fix the cached value to "no proxy" and make
+// setting HTTPS_PROXY here have no effect.
+func TestProxySupport(t *testing.T) {
+	if os.Getenv(proxyChildEnv) != "1" {
+		reExecForProxyTest(t)
+		return
+	}
+
+	backend := startTCPServer(t)
+	proxyAddr, connectTargets := startConnectProxy(t, backend)
+
+	// Safe to set here: this is a fresh process and nothing has dialed yet.
+	t.Setenv("HTTPS_PROXY", "http://"+proxyAddr)
+	t.Setenv("NO_PROXY", "")
+	t.Setenv("no_proxy", "")
+
+	// WithNoProxy must dial the resolved address directly. A missing port
+	// fails locally without DNS or network access; the proxy would accept it.
+	directResolver := manual.NewBuilderWithScheme("dns")
+	directResolver.InitialState(resolver.State{Addresses: []resolver.Address{{Addr: "missing-port"}}})
+	localResolver := manual.NewBuilderWithScheme("dns")
+	const resolvedTarget = "grpcurl-resolved-proxy-test.invalid:443"
+	localResolver.InitialState(resolver.State{Addresses: []resolver.Address{{Addr: resolvedTarget}}})
+	customDialer := func(ctx context.Context, address string) (net.Conn, error) {
+		return (&net.Dialer{}).DialContext(ctx, "tcp", backend)
+	}
+
+	for _, tc := range []struct {
+		name          string
+		target        string
+		opts          []grpc.DialOption
+		wantProxy     bool
+		wantError     error
+		connectTarget string
+	}{
+		{name: "bare address", target: proxyTarget, wantProxy: true},
+		{name: "dns address", target: "dns:///" + proxyTarget, wantProxy: true},
+		{
+			// TODO: https://github.com/fullstorydev/grpcurl/issues/581
+			// The malformed resolved address should fail promptly with "missing
+			// port in address". The timeout is current behavior; bypassing the
+			// proxy is the desired behavior that this case also verifies.
+			name:      "proxy disabled",
+			target:    "dns:///" + proxyTarget,
+			opts:      []grpc.DialOption{grpc.WithResolvers(directResolver), grpc.WithNoProxy()},
+			wantError: context.DeadlineExceeded,
+		},
+		{
+			name:          "local DNS resolution",
+			target:        "dns:///" + proxyTarget,
+			opts:          []grpc.DialOption{grpc.WithResolvers(localResolver), grpc.WithLocalDNSResolution()},
+			wantProxy:     true,
+			connectTarget: resolvedTarget,
+		},
+		{
+			name:   "custom dialer",
+			target: proxyTarget,
+			opts:   []grpc.DialOption{grpc.WithContextDialer(customDialer)},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			before := len(connectTargets())
+			timeout := dialTimeout
+			if tc.wantError != nil {
+				timeout = time.Second
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), timeout)
+			defer cancel()
+
+			cc, err := BlockingDial(ctx, "", tc.target, nil, tc.opts...)
+			if cc != nil {
+				defer cc.Close()
+			}
+			if tc.wantError != nil {
+				if !errors.Is(err, tc.wantError) {
+					t.Fatalf("BlockingDial(%q) error = %v, want %v", tc.target, err, tc.wantError)
+				}
+			} else if err != nil {
+				t.Fatalf("BlockingDial(%q) failed: %v\nCONNECT requests seen by proxy: %v",
+					tc.target, err, connectTargets()[before:])
+			} else {
+				simpleTest(t, cc)
+			}
+
+			seen := connectTargets()[before:]
+			if !tc.wantProxy {
+				if len(seen) != 0 {
+					t.Fatalf("proxy should be bypassed, got CONNECT requests: %v", seen)
+				}
+				return
+			}
+			if len(seen) == 0 {
+				t.Fatal("proxy received no CONNECT requests")
+			}
+			wantTarget := tc.connectTarget
+			if wantTarget == "" {
+				wantTarget = proxyTarget
+			}
+			for _, target := range seen {
+				if target != wantTarget {
+					t.Errorf("proxy received CONNECT for %q, want %q", target, wantTarget)
+				}
+			}
+		})
+	}
+}
+
+// reExecForProxyTest runs this test again in a child process, where the proxy
+// environment has not yet been resolved and cached.
+func reExecForProxyTest(t *testing.T) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestProxySupport$", "-test.v", "-test.timeout=55s")
+	cmd.Env = append(os.Environ(), proxyChildEnv+"=1")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("proxy test child process failed: %v\n%s", err, out)
+	}
+}
+
+// startConnectProxy starts a minimal HTTP CONNECT proxy on loopback. It
+// records every target it is asked to connect to, then tunnels to backendAddr
+// regardless of what was requested. That indirection is what lets the test use
+// an unresolvable target: the client only ever sends the name as text in the
+// CONNECT request, and never resolves it itself.
+//
+// The returned function reports the targets seen so far.
+func startConnectProxy(t *testing.T, backendAddr string) (proxyAddr string, connectTargets func() []string) {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen for proxy: %v", err)
+	}
+	t.Cleanup(func() { l.Close() })
+
+	var mu sync.Mutex
+	var targets []string
+
+	go func() {
+		for {
+			conn, err := l.Accept()
+			if err != nil {
+				return // listener closed at test cleanup
+			}
+			go proxyOneConn(conn, backendAddr, func(target string) {
+				mu.Lock()
+				defer mu.Unlock()
+				targets = append(targets, target)
+			})
+		}
+	}()
+
+	return l.Addr().String(), func() []string {
+		mu.Lock()
+		defer mu.Unlock()
+		return append([]string(nil), targets...)
+	}
+}
+
+// proxyOneConn handles a single CONNECT request and then bridges the tunnel.
+func proxyOneConn(conn net.Conn, backendAddr string, record func(string)) {
+	defer conn.Close()
+
+	br := bufio.NewReader(conn)
+	requestLine, err := br.ReadString('\n')
+	if err != nil {
+		return
+	}
+	// e.g. "CONNECT grpcurl-proxy-test.invalid:443 HTTP/1.1"
+	fields := strings.Fields(requestLine)
+	if len(fields) < 2 || fields[0] != "CONNECT" {
+		return
+	}
+	record(fields[1])
+
+	// Discard the remaining request headers.
+	for {
+		line, err := br.ReadString('\n')
+		if err != nil || strings.TrimSpace(line) == "" {
+			break
+		}
+	}
+
+	if _, err := conn.Write([]byte("HTTP/1.1 200 Connection Established\r\n\r\n")); err != nil {
+		return
+	}
+
+	upstream, err := net.Dial("tcp", backendAddr)
+	if err != nil {
+		return
+	}
+	defer upstream.Close()
+
+	// Bridge until either side closes. br may hold buffered bytes already read
+	// from conn, so copy from it rather than from conn directly.
+	go func() { _, _ = io.Copy(upstream, br) }()
+	_, _ = io.Copy(conn, upstream)
+}


### PR DESCRIPTION
Add coverage for TCP and Unix connection success and failure, including RPCs over successful connections. Exercise HTTP CONNECT proxy routing for bare and explicit DNS targets, local DNS resolution, proxy bypass, custom resolvers and dialers, retries, connection use after dial-context cancellation, and reconnection. Isolate cached proxy settings in a child process and clear inherited proxy exclusions.

Some assertions deliberately record current behavior, not desired behavior. Refused TCP connections and missing Unix sockets currently return context deadline exceeded. The desired behavior is fast failure, highlighting the underlying dial error, such as connection refused or no such file or directory. Unfortunately this isn't always the current behavior.

Mark these expectations with TODOs linking to: https://github.com/fullstorydev/grpcurl/issues/581

Keeping the current assertions lets these tests land without application changes and makes future behavior changes visible in review.

Validation: `go test -race ./...`, three shuffled race runs of the new tests with `NO_PROXY` and `no_proxy` set to `*`, `go vet ./...`, formatting and diff checks. Windows amd64 test compilation passed; Windows tests were not executed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only new tests and helpers; no changes to `BlockingDial` or production dial/proxy logic.
> 
> **Overview**
> Adds a **test-only** suite around `BlockingDial`, with shared helpers to spin up TCP/Unix gRPC servers and assert dial success (including RPCs) or failure.
> 
> **Dial behavior:** Covers empty/`tcp` networks, Unix (`unix://` + bare path on Unix OSes), rejecting `tcp` + Unix addresses, dial retries and reconnect via `bufconn`, connections surviving dial-context cancellation, and DNS targets with `WithNoProxy` plus custom resolvers/dialers (ensuring `dns://` is not rewritten to passthrough).
> 
> **Proxy behavior:** `TestProxySupport` re-execs the test binary so `HTTPS_PROXY` is not cached from earlier dials, then drives a local HTTP CONNECT proxy to verify bare and `dns:///` targets, local DNS resolution, `WithNoProxy` bypass, and that `WithContextDialer` skips the proxy.
> 
> Several failure cases **document today’s behavior** (context deadline on refused TCP, missing Unix socket, some permanent dial errors) with TODOs to [#581](https://github.com/fullstorydev/grpcurl/issues/581) for prompt, underlying errors later.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c6f9bfe64428a6b88c0ac4d6037edfa8595fca9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->